### PR TITLE
[CB-7] Add spec coverage with simplecov and code climate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+env:
+  global:
+    - CC_TEST_REPORTER_ID=dfd84bd4971ce33364328e989da246eff3a0346e548bd51db423d0339c75c32d
 language: ruby
 sudo: false
 rvm:
@@ -5,6 +8,12 @@ rvm:
 branches:
   only:
     - master
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
 script:
   - bundle exec rspec
   - bundle exec rubocop
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Crystalball is a Ruby library which implements [Regression Test Selection mechanism](https://tenderlovemaking.com/2015/02/13/predicting-test-failues.html) originally published by Aaron Patterson. Its main purpose is to select a subset of your test suite which should be run to ensure your changes didn't break anything.
 
 [![Build Status](https://travis-ci.org/toptal/crystalball.svg?branch=master)](https://travis-ci.org/toptal/crystalball)
+[![Maintainability](https://api.codeclimate.com/v1/badges/c8bfc25a43a1a2ecf964/maintainability)](https://codeclimate.com/github/toptal/crystalball/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/c8bfc25a43a1a2ecf964/test_coverage)](https://codeclimate.com/github/toptal/crystalball/test_coverage)
 
 ## Installation
 

--- a/crystalball.gemspec
+++ b/crystalball.gemspec
@@ -38,4 +38,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rubocop-rspec'
+  spec.add_development_dependency 'simplecov'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
+require 'simplecov'
+SimpleCov.start
+
 require "crystalball"
 
 RSpec.configure do |config|


### PR DESCRIPTION
Codeclimate doesn't display reports in PR, although with debug output enabled it shows that everything is working successfully. Might be due to the fact that we don't have coverage for master and it doesn't have anything to compare to. Will investigate after we merge this.