### PR TITLE
Update repo link in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,5 +53,5 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/pluff/crystalball. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/toptal/crystalball. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 


### PR DESCRIPTION
Just an update of the repo URL. Apparently the repo originates from @pluff and the link in the README is outdated since the project joined toptal namespace.