### PR TITLE
Properly count in predicted failures when there is full file prediction

### DIFF
--- a/lib/crystalball/predictor_evaluator.rb
+++ b/lib/crystalball/predictor_evaluator.rb
@@ -11,7 +11,9 @@ module Crystalball
     end
 
     def predicted_failures
-      @predicted_failures ||= actual_failures & prediction
+      @predicted_failures ||= actual_failures.select do |failure|
+        prediction.any? { |p| failure.include?(p) }
+      end
     end
 
     def unpredicted_failures

--- a/spec/predictor_evaluator_spec.rb
+++ b/spec/predictor_evaluator_spec.rb
@@ -14,6 +14,14 @@ describe Crystalball::PredictorEvaluator do
     it 'returns all cases that present in actual failures and prediction' do
       expect(evaluator.predicted_failures).to eq %w[file1.rb[1:1]]
     end
+
+    context 'with prediction as full file' do
+      let(:prediction) { %w[file2.rb] }
+
+      it 'returns all cases matching that file' do
+        expect(evaluator.predicted_failures).to eq %w[file2.rb[1:2]]
+      end
+    end
   end
 
   describe '#unpredicted_failures' do


### PR DESCRIPTION
E.g. failure `./models/my_model.rb[1:2]` is predicted when there is a `./models/my_model.rb` in prediction