### PR TITLE
Shrink prediction to only root when prediction contains it

### DIFF
--- a/lib/crystalball/prediction.rb
+++ b/lib/crystalball/prediction.rb
@@ -7,12 +7,17 @@ module Crystalball
       @cases = cases
     end
 
+    # When the cases are something like:
+    #   ./spec/foo ./spec/foo/bar_spec.rb
+    # this returns just ./spec/foo
     def compact
-      result = []
-      sort_by(&:length).each do |c|
+      shrinked_cases = sort_by(&:length).each_with_object([]) do |c, result|
         result << c unless result.any? { |r| c.start_with?(r, "./#{r}") }
-      end
-      result
+      end.compact
+
+      return %w[./] if (shrinked_cases & %w[. ./]).any?
+
+      shrinked_cases
     end
 
     def to_a

--- a/spec/prediction_spec.rb
+++ b/spec/prediction_spec.rb
@@ -26,6 +26,36 @@ describe Crystalball::Prediction do
 
       it { is_expected.to match_array(%w[dir/ file2_spec.rb]) }
     end
+
+    context 'when prediction includes root' do
+      let(:raw_cases) do
+        %w[
+          ./
+          dir/file1_spec.rb
+          ./dir/file1_spec.rb
+          dir/
+          file2_spec.rb
+          file2_spec.rb[1:1]
+        ]
+      end
+
+      it { is_expected.to match_array(%w[./]) }
+
+      context 'when root is just `.`' do
+        let(:raw_cases) do
+          %w[
+            .
+            dir/file1_spec.rb
+            ./dir/file1_spec.rb
+            dir/
+            file2_spec.rb
+            file2_spec.rb[1:1]
+          ]
+        end
+
+        it { is_expected.to match_array(%w[./]) }
+      end
+    end
   end
 
   describe '#method_missing' do


### PR DESCRIPTION
Before this, a prediction in changes that triggered the full build (`./`) would be redundant like `./ ./spec/foo_spec.rb`; now it's just `./`.