### PR TITLE
 Unify predictor output to match RSpec example format

### DIFF
--- a/features/associated_specs/change_spec.rb
+++ b/features/associated_specs/change_spec.rb
@@ -3,17 +3,19 @@
 require_relative '../feature_helper'
 
 describe 'Changing associated source file' do
-  subject(:forecast) do
-    Crystalball.foresee(workdir: root, map_path: root.join('execution_map.yml')) do |predictor|
-      predictor.use Crystalball::Predictor::AssociatedSpecs.new from: %r{models/(?<file>.*).rb},
-                                                                to: './spec/models/%<file>s_spec.rb'
-    end
-  end
   include_context 'simple git repository'
+  include_context 'base forecast'
+
+  let(:strategies) do
+    [
+      Crystalball::Predictor::AssociatedSpecs.new(from: %r{models/(?<file>.*).rb},
+                                                  to: 'spec/models/%<file>s_spec.rb')
+    ]
+  end
 
   it 'adds matched spec to a prediction list' do
     change model1_path
 
-    is_expected.to match_array(%w[./spec/models/model1_spec.rb])
+    expect(forecast).to match_array(%w[./spec/models/model1_spec.rb])
   end
 end

--- a/features/associated_specs/delete_spec.rb
+++ b/features/associated_specs/delete_spec.rb
@@ -3,17 +3,19 @@
 require_relative '../feature_helper'
 
 describe 'Deleting associated source file' do
-  subject(:forecast) do
-    Crystalball.foresee(workdir: root, map_path: root.join('execution_map.yml')) do |predictor|
-      predictor.use Crystalball::Predictor::AssociatedSpecs.new from: %r{models/(?<file>.*).rb},
-                                                                to: './spec/models/%<file>s_spec.rb'
-    end
-  end
   include_context 'simple git repository'
+  include_context 'base forecast'
+
+  let(:strategies) do
+    [
+      Crystalball::Predictor::AssociatedSpecs.new(from: %r{models/(?<file>.*).rb},
+                                                  to: 'spec/models/%<file>s_spec.rb')
+    ]
+  end
 
   it 'adds matched spec to a prediction list' do
     delete model1_path
 
-    is_expected.to match_array(%w[./spec/models/model1_spec.rb])
+    expect(forecast).to match_array(%w[./spec/models/model1_spec.rb])
   end
 end

--- a/features/modified_execution_paths/change_and_commit_spec.rb
+++ b/features/modified_execution_paths/change_and_commit_spec.rb
@@ -3,19 +3,19 @@
 require_relative '../feature_helper'
 
 describe 'Changing and commiting a source file' do
-  subject(:forecast) do
-    Crystalball.foresee(workdir: root, map_path: root.join('execution_map.yml')) do |predictor|
-      predictor.use Crystalball::Predictor::ModifiedExecutionPaths.new
-    end
-  end
   include_context 'simple git repository'
   include_context 'class1 examples'
+  include_context 'base forecast'
+
+  let(:strategies) do
+    [Crystalball::Predictor::ModifiedExecutionPaths.new]
+  end
 
   it 'adds mapped examples to a prediction list' do
     change class1_path
     git.add class1_path.to_s
     git.commit 'Second commit'
 
-    is_expected.to include(*class1_examples)
+    expect(forecast).to include(*class1_examples)
   end
 end

--- a/features/modified_execution_paths/change_spec.rb
+++ b/features/modified_execution_paths/change_spec.rb
@@ -3,31 +3,31 @@
 require_relative '../feature_helper'
 
 describe 'Changing source file' do
-  subject(:forecast) do
-    Crystalball.foresee(workdir: root, map_path: root.join('execution_map.yml')) do |predictor|
-      predictor.use Crystalball::Predictor::ModifiedExecutionPaths.new
-    end
-  end
   include_context 'simple git repository'
   include_context 'class1 examples'
   include_context 'model1 examples'
+  include_context 'base forecast'
+
+  let(:strategies) do
+    [Crystalball::Predictor::ModifiedExecutionPaths.new]
+  end
 
   it 'adds mapped examples to a prediction list for Class1 definition' do
     change class1_path
 
-    is_expected.to include(*class1_examples)
+    expect(forecast).to include(*class1_examples)
   end
 
   it 'adds mapped examples to a prediction list for Class1 reopen' do
     change class1_reopen_path
 
-    is_expected.to include(*class1_examples)
+    expect(forecast).to include(*class1_examples)
   end
 
   it 'adds mapped examples to a prediction list for Class2 definition' do
     change class2_path
 
-    is_expected.to include(
+    expect(forecast).to include(
       './spec/class2_spec.rb[1:1:1]',
       './spec/class2_spec.rb[1:1:2:1]',
       './spec/class2_spec.rb[1:1:3:1]',
@@ -45,7 +45,7 @@ describe 'Changing source file' do
   it 'adds mapped examples to a prediction list for Module1 definition' do
     change module1_path
 
-    is_expected.to include(
+    expect(forecast).to include(
       './spec/class1_spec.rb[1:1:1]',
       './spec/class1_spec.rb[1:1:2:1]',
       './spec/class1_spec.rb[1:1:3:1]',
@@ -65,7 +65,7 @@ describe 'Changing source file' do
   it 'adds mapped examples to a prediction list for Module2 definition' do
     change module2_path
 
-    is_expected.to include(
+    expect(forecast).to include(
       './spec/class2_spec.rb[1:1:1]',
       './spec/class2_spec.rb[1:1:2:1]',
       './spec/class2_spec.rb[1:1:3:1]',
@@ -81,13 +81,13 @@ describe 'Changing source file' do
   it 'adds mapped examples to a prediction list for Model1 definition' do
     change model1_path
 
-    is_expected.to include(*model1_examples)
+    expect(forecast).to include(*model1_examples)
   end
 
   it 'adds mapped examples to a prediction list for _item view' do
     change item_view_path
 
-    is_expected.to include(
+    expect(forecast).to include(
       './spec/views/index.html.erb_spec.rb[1:1]',
       './spec/views/index.html.erb_spec.rb[1:2]',
       './spec/views/index.html.erb_spec.rb[1:3]',
@@ -98,7 +98,7 @@ describe 'Changing source file' do
   it 'adds mapped examples to a prediction list for name locale' do
     change name_locale_path
 
-    is_expected.to include(
+    expect(forecast).to include(
       './spec/class1_spec.rb[1:3:1]',
       './spec/class2_spec.rb[1:3:1]'
     )
@@ -107,7 +107,7 @@ describe 'Changing source file' do
   it 'adds mapped examples to a prediction list for value locale' do
     change value_locale_path
 
-    is_expected.to include(
+    expect(forecast).to include(
       './spec/class2_spec.rb[1:6:1]'
     )
   end

--- a/features/modified_execution_paths/delete_spec.rb
+++ b/features/modified_execution_paths/delete_spec.rb
@@ -3,17 +3,17 @@
 require_relative '../feature_helper'
 
 describe 'Deleting source file' do
-  subject(:forecast) do
-    Crystalball.foresee(workdir: root, map_path: root.join('execution_map.yml')) do |predictor|
-      predictor.use Crystalball::Predictor::ModifiedExecutionPaths.new
-    end
-  end
   include_context 'simple git repository'
   include_context 'class1 examples'
+  include_context 'base forecast'
+
+  let(:strategies) do
+    [Crystalball::Predictor::ModifiedExecutionPaths.new]
+  end
 
   it 'adds mapped examples to a prediction list' do
     delete class1_path
 
-    is_expected.to include(*class1_examples)
+    expect(forecast).to include(*class1_examples)
   end
 end

--- a/features/modified_execution_paths/move_spec.rb
+++ b/features/modified_execution_paths/move_spec.rb
@@ -3,17 +3,17 @@
 require_relative '../feature_helper'
 
 describe 'Moving source file' do
-  subject(:forecast) do
-    Crystalball.foresee(workdir: root, map_path: root.join('execution_map.yml')) do |predictor|
-      predictor.use Crystalball::Predictor::ModifiedExecutionPaths.new
-    end
-  end
   include_context 'simple git repository'
   include_context 'class1 examples'
+  include_context 'base forecast'
+
+  let(:strategies) do
+    [Crystalball::Predictor::ModifiedExecutionPaths.new]
+  end
 
   it 'adds mapped examples to a prediction list' do
     move class1_path
 
-    is_expected.to include(*class1_examples)
+    expect(forecast).to include(*class1_examples)
   end
 end

--- a/features/modified_schema/change_spec.rb
+++ b/features/modified_schema/change_spec.rb
@@ -3,17 +3,17 @@
 require_relative '../feature_helper'
 
 describe 'Changing schema file' do
-  subject(:forecast) do
-    Crystalball.foresee(workdir: root, map_path: root.join('execution_map.yml')) do |predictor|
-      predictor.use Crystalball::Rails::Predictor::ModifiedSchema.new(tables_map_path: root.join('tables_map.yml'))
-    end
-  end
   include_context 'simple git repository'
   include_context 'model1 examples'
+  include_context 'base forecast'
+
+  let(:strategies) do
+    [Crystalball::Rails::Predictor::ModifiedSchema.new(tables_map_path: root.join('tables_map.yml'))]
+  end
 
   it 'adds mapped examples to a prediction list' do
     change schema_path
 
-    is_expected.to include(*model1_examples)
+    expect(forecast).to include(*model1_examples)
   end
 end

--- a/features/modified_specs/create_spec.rb
+++ b/features/modified_specs/create_spec.rb
@@ -3,13 +3,10 @@
 require_relative '../feature_helper'
 
 describe 'Creating spec file' do
-  subject(:forecast) do
-    Crystalball.foresee(workdir: root, map_path: root.join('execution_map.yml')) do |predictor|
-      predictor.use Crystalball::Predictor::ModifiedSpecs.new
-    end
-  end
-
   include_context 'simple git repository'
+  include_context 'base forecast'
+
+  let(:strategies) { [Crystalball::Predictor::ModifiedSpecs.new] }
 
   it 'adds it to a prediction list' do
     new_spec_path = spec_path.join('new_spec.rb')
@@ -22,6 +19,6 @@ describe 'Creating spec file' do
     RUBY
     git.add(new_spec_path.to_s)
 
-    is_expected.to match_array(%w[./spec/new_spec.rb])
+    expect(forecast).to match_array(%w[./spec/new_spec.rb])
   end
 end

--- a/features/modified_specs/create_spec.rb
+++ b/features/modified_specs/create_spec.rb
@@ -22,6 +22,6 @@ describe 'Creating spec file' do
     RUBY
     git.add(new_spec_path.to_s)
 
-    is_expected.to match_array(%w[spec/new_spec.rb])
+    is_expected.to match_array(%w[./spec/new_spec.rb])
   end
 end

--- a/features/modified_specs/delete_spec.rb
+++ b/features/modified_specs/delete_spec.rb
@@ -3,16 +3,14 @@
 require_relative '../feature_helper'
 
 describe 'Deleting spec file' do
-  subject(:forecast) do
-    Crystalball.foresee(workdir: root, map_path: root.join('execution_map.yml')) do |predictor|
-      predictor.use Crystalball::Predictor::ModifiedSpecs.new
-    end
-  end
   include_context 'simple git repository'
+  include_context 'base forecast'
+
+  let(:strategies) { [Crystalball::Predictor::ModifiedSpecs.new] }
 
   it 'does not add it to a prediction list' do
-    git.lib.remove class1_spec_path
+    delete class1_spec_path
 
-    is_expected.to match_array([])
+    expect(forecast).to match_array([])
   end
 end

--- a/features/modified_specs/move_spec.rb
+++ b/features/modified_specs/move_spec.rb
@@ -3,16 +3,14 @@
 require_relative '../feature_helper'
 
 describe 'Moving spec file' do
-  subject(:forecast) do
-    Crystalball.foresee(workdir: root, map_path: root.join('execution_map.yml')) do |predictor|
-      predictor.use Crystalball::Predictor::ModifiedSpecs.new
-    end
-  end
   include_context 'simple git repository'
+  include_context 'base forecast'
+
+  let(:strategies) { [Crystalball::Predictor::ModifiedSpecs.new] }
 
   it 'adds it to a prediction list' do
     move(class1_spec_path)
 
-    is_expected.to match_array(%w[./spec/moved_class1_spec.rb])
+    expect(forecast).to match_array(%w[./spec/moved_class1_spec.rb])
   end
 end

--- a/features/modified_specs/move_spec.rb
+++ b/features/modified_specs/move_spec.rb
@@ -13,6 +13,6 @@ describe 'Moving spec file' do
   it 'adds it to a prediction list' do
     move(class1_spec_path)
 
-    is_expected.to match_array(%w[spec/moved_class1_spec.rb])
+    is_expected.to match_array(%w[./spec/moved_class1_spec.rb])
   end
 end

--- a/features/modified_support_specs/change_spec.rb
+++ b/features/modified_support_specs/change_spec.rb
@@ -3,19 +3,17 @@
 require_relative '../feature_helper'
 
 describe 'Changing support spec file' do
-  subject(:forecast) do
-    Crystalball.foresee(workdir: root, map_path: root.join('execution_map.yml')) do |predictor|
-      predictor.use Crystalball::Predictor::ModifiedSupportSpecs.new
-    end
-  end
   include_context 'simple git repository'
+  include_context 'base forecast'
+
+  let(:strategies) { [Crystalball::Predictor::ModifiedSupportSpecs.new] }
 
   it 'adds full spec to a prediction list' do
     change action_view_shared_context
 
-    is_expected.to match_array([
-                                 './spec/views/index.html.erb_spec.rb',
-                                 './spec/views/show.html.erb_spec.rb'
-                               ])
+    expect(forecast).to match_array([
+                                      './spec/views/index.html.erb_spec.rb',
+                                      './spec/views/show.html.erb_spec.rb'
+                                    ])
   end
 end

--- a/features/modified_support_specs/delete_spec.rb
+++ b/features/modified_support_specs/delete_spec.rb
@@ -3,19 +3,17 @@
 require_relative '../feature_helper'
 
 describe 'Deleting support spec file' do
-  subject(:forecast) do
-    Crystalball.foresee(workdir: root, map_path: root.join('execution_map.yml')) do |predictor|
-      predictor.use Crystalball::Predictor::ModifiedSupportSpecs.new
-    end
-  end
   include_context 'simple git repository'
+  include_context 'base forecast'
+
+  let(:strategies) { [Crystalball::Predictor::ModifiedSupportSpecs.new] }
 
   it 'adds full spec to a prediction list' do
-    git.lib.remove action_view_shared_context
+    delete action_view_shared_context
 
-    is_expected.to match_array([
-                                 './spec/views/index.html.erb_spec.rb',
-                                 './spec/views/show.html.erb_spec.rb'
-                               ])
+    expect(forecast).to match_array([
+                                      './spec/views/index.html.erb_spec.rb',
+                                      './spec/views/show.html.erb_spec.rb'
+                                    ])
   end
 end

--- a/features/modified_support_specs/move_spec.rb
+++ b/features/modified_support_specs/move_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative '../feature_helper'
+
+describe 'Moving support spec file' do
+  include_context 'simple git repository'
+  include_context 'base forecast'
+
+  let(:strategies) { [Crystalball::Predictor::ModifiedSupportSpecs.new] }
+
+  it 'adds full spec to a prediction list' do
+    move action_view_shared_context
+
+    expect(forecast).to match_array([
+                                      './spec/views/index.html.erb_spec.rb',
+                                      './spec/views/show.html.erb_spec.rb'
+                                    ])
+  end
+end

--- a/features/support/shared_contexts/base_forecast.rb
+++ b/features/support/shared_contexts/base_forecast.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+shared_context 'base forecast' do
+  subject(:forecast) { predictor.prediction.compact }
+  let(:predictor) do
+    Crystalball::Predictor.new(map, repo, from: map.commit) do |predictor|
+      strategies.each { |strategy| predictor.use strategy }
+    end
+  end
+  let(:strategies) { [] } # to be overriden
+  let(:map) { Crystalball::MapStorage::YAMLStorage.load(Pathname.new(root.join('execution_map.yml'))) }
+  let(:repo) { Crystalball::GitRepo.open(Pathname.new(workdir)) }
+  let(:workdir) { root }
+end

--- a/features/support/shared_contexts/base_forecast.rb
+++ b/features/support/shared_contexts/base_forecast.rb
@@ -3,12 +3,12 @@
 shared_context 'base forecast' do
   subject(:forecast) { predictor.prediction.compact }
   let(:predictor) do
-    Crystalball::Predictor.new(map, repo, from: map.commit) do |predictor|
+    Crystalball::Predictor.new(execution_map, repo, from: execution_map.commit) do |predictor|
       strategies.each { |strategy| predictor.use strategy }
     end
   end
-  let(:strategies) { [] } # to be overriden
-  let(:map) { Crystalball::MapStorage::YAMLStorage.load(Pathname.new(root.join('execution_map.yml'))) }
+  let(:strategies) { [] } # to be overridden
+  let(:execution_map) { Crystalball::MapStorage::YAMLStorage.load(Pathname.new(root.join('execution_map.yml'))) }
   let(:repo) { Crystalball::GitRepo.open(Pathname.new(workdir)) }
   let(:workdir) { root }
 end

--- a/lib/crystalball/prediction.rb
+++ b/lib/crystalball/prediction.rb
@@ -11,13 +11,9 @@ module Crystalball
     #   ./spec/foo ./spec/foo/bar_spec.rb
     # this returns just ./spec/foo
     def compact
-      shrinked_cases = sort_by(&:length).each_with_object([]) do |c, result|
-        result << c unless result.any? { |r| c.start_with?(r, "./#{r}") }
+      sort_by(&:length).each_with_object([]) do |c, result|
+        result << c unless result.any? { |r| c.start_with?(r) }
       end.compact
-
-      return %w[./] if (shrinked_cases & %w[. ./]).any?
-
-      shrinked_cases
     end
 
     def to_a

--- a/lib/crystalball/predictor/associated_specs.rb
+++ b/lib/crystalball/predictor/associated_specs.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
+require 'crystalball/predictor/strategy'
+
 module Crystalball
   class Predictor
     # Used with `predictor.use Crystalball::Predictor::AssociatedSpecs.new(from: %r{models/(.*).rb}, to: "./spec/models/%s_spec.rb")`.
     # When used will look for files matched to `from` regex and use captures to fill `to` string to
     # get paths of proper specs
     class AssociatedSpecs
+      include Strategy
+
       # @param [Regexp] from - regular expression to match specific files and get proper captures
       # @param [String] to - string in sprintf format to get proper files using captures of regexp
       def initialize(from:, to:)
@@ -18,9 +22,10 @@ module Crystalball
       # @param [Crystalball::SourceDiff] diff - the diff from which to predict
       #   which specs should run
       # @return [Array<String>] the spec paths associated with the changes
-      def call(diff, _)
-        diff.map(&:relative_path).grep(from)
-            .map { |source_file_path| to % captures(source_file_path) }
+      def call(diff, _map)
+        super do
+          diff.map(&:relative_path).grep(from).map { |source_file_path| to % captures(source_file_path) }
+        end
       end
 
       private

--- a/lib/crystalball/predictor/helpers/path_formatter.rb
+++ b/lib/crystalball/predictor/helpers/path_formatter.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Crystalball
+  class Predictor
+    module Helpers
+      # Helper module for converting relative path to RSpec format
+      module PathFormatter
+        def format_paths(paths)
+          paths.map { |path| format_path(path) }
+        end
+
+        def format_path(path)
+          path.start_with?('./') ? path : "./#{path}"
+        end
+      end
+    end
+  end
+end

--- a/lib/crystalball/predictor/modified_execution_paths.rb
+++ b/lib/crystalball/predictor/modified_execution_paths.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'crystalball/predictor/strategy'
 require 'crystalball/predictor/helpers/affected_examples_detector'
 
 module Crystalball
@@ -8,7 +9,8 @@ module Crystalball
     # specs depend on which files and will return only those specs which depend on files modified since last time map
     # was generated.
     class ModifiedExecutionPaths
-      include ::Crystalball::Predictor::Helpers::AffectedExamplesDetector
+      include Helpers::AffectedExamplesDetector
+      include Strategy
 
       # @param [Crystalball::SourceDiff] diff - the diff from which to predict
       #   which specs should run
@@ -16,7 +18,9 @@ module Crystalball
       #   examples and affected files
       # @return [Array<String>] the spec paths associated with the changes
       def call(diff, map)
-        detect_examples(diff.map(&:relative_path), map)
+        super do
+          detect_examples(diff.map(&:relative_path), map)
+        end
       end
     end
   end

--- a/lib/crystalball/predictor/modified_specs.rb
+++ b/lib/crystalball/predictor/modified_specs.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
+require 'crystalball/predictor/strategy'
+
 module Crystalball
   class Predictor
     # Used with `predictor.use Crystalball::Predictor::ModifiedSpecs.new`. Will find files that match spec regexp and
     # return all new or modified files. You can specify spec regexp using first parameter to `#initialize`.
     class ModifiedSpecs
+      include Strategy
+
       # @param [Regexp] spec_pattern - regexp to filter specs files
       def initialize(spec_pattern = %r{spec/.*_spec\.rb\z})
         @spec_pattern = spec_pattern
@@ -16,7 +20,9 @@ module Crystalball
       #   which specs should run
       # @return [Array<String>] the spec paths associated with the changes
       def call(diff, _)
-        diff.reject(&:deleted?).map(&:new_relative_path).grep(spec_pattern)
+        super do
+          diff.reject(&:deleted?).map(&:new_relative_path).grep(spec_pattern)
+        end
       end
 
       private

--- a/lib/crystalball/predictor/modified_support_specs.rb
+++ b/lib/crystalball/predictor/modified_support_specs.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'crystalball/predictor/strategy'
 require 'crystalball/predictor/helpers/affected_examples_detector'
 
 module Crystalball
@@ -7,7 +8,8 @@ module Crystalball
     # Used with `predictor.use Crystalball::Predictor::ModifiedSupportSpecs.new`. Will find files that match passed regexp and
     # return full spec files which uses matched support spec files. Perfectly works for shared_context and shared_examples.
     class ModifiedSupportSpecs
-      include ::Crystalball::Predictor::Helpers::AffectedExamplesDetector
+      include Strategy
+      include Helpers::AffectedExamplesDetector
 
       # @param [Regexp] support_spec_pattern - regexp to filter support specs files
       def initialize(support_spec_pattern = %r{spec/support/.*\.rb\z})
@@ -20,11 +22,13 @@ module Crystalball
       #   examples and affected files
       # @return [Array<String>] the spec paths associated with the changes
       def call(diff, map)
-        changed_support_files = diff.map(&:new_relative_path).grep(support_spec_pattern)
+        super do
+          changed_support_files = diff.map(&:new_relative_path).grep(support_spec_pattern)
 
-        examples = detect_examples(changed_support_files, map)
+          examples = detect_examples(changed_support_files, map)
 
-        examples.map { |e| e.to_s.split('[').first }.uniq
+          examples.map { |e| e.to_s.split('[').first }.uniq
+        end
       end
 
       private

--- a/lib/crystalball/predictor/modified_support_specs.rb
+++ b/lib/crystalball/predictor/modified_support_specs.rb
@@ -23,7 +23,7 @@ module Crystalball
       # @return [Array<String>] the spec paths associated with the changes
       def call(diff, map)
         super do
-          changed_support_files = diff.map(&:new_relative_path).grep(support_spec_pattern)
+          changed_support_files = diff.map(&:relative_path).grep(support_spec_pattern)
 
           examples = detect_examples(changed_support_files, map)
 

--- a/lib/crystalball/predictor/strategy.rb
+++ b/lib/crystalball/predictor/strategy.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'crystalball/predictor/helpers/path_formatter'
+
+module Crystalball
+  class Predictor
+    # Base module to include in any strategy. Provides output formatting similar to RSpec
+    module Strategy
+      include Helpers::PathFormatter
+
+      def call(*)
+        format_paths(yield)
+      end
+    end
+  end
+end

--- a/spec/prediction_spec.rb
+++ b/spec/prediction_spec.rb
@@ -16,45 +16,28 @@ describe Crystalball::Prediction do
     context 'when one part is included into other part' do
       let(:raw_cases) do
         %w[
-          dir/file1_spec.rb
           ./dir/file1_spec.rb
-          dir/
-          file2_spec.rb
-          file2_spec.rb[1:1]
+          ./dir/
+          ./file2_spec.rb
+          ./file2_spec.rb[1:1]
         ]
       end
 
-      it { is_expected.to match_array(%w[dir/ file2_spec.rb]) }
+      it { is_expected.to match_array(%w[./dir/ ./file2_spec.rb]) }
     end
 
     context 'when prediction includes root' do
       let(:raw_cases) do
         %w[
           ./
-          dir/file1_spec.rb
           ./dir/file1_spec.rb
-          dir/
-          file2_spec.rb
-          file2_spec.rb[1:1]
+          ./dir/
+          ./file2_spec.rb
+          ./file2_spec.rb[1:1]
         ]
       end
 
       it { is_expected.to match_array(%w[./]) }
-
-      context 'when root is just `.`' do
-        let(:raw_cases) do
-          %w[
-            .
-            dir/file1_spec.rb
-            ./dir/file1_spec.rb
-            dir/
-            file2_spec.rb
-            file2_spec.rb[1:1]
-          ]
-        end
-
-        it { is_expected.to match_array(%w[./]) }
-      end
     end
   end
 

--- a/spec/predictor/associated_specs_spec.rb
+++ b/spec/predictor/associated_specs_spec.rb
@@ -11,7 +11,7 @@ describe Crystalball::Predictor::AssociatedSpecs do
   describe '#call' do
     subject { predictor.call(diff, {}) }
 
-    it { is_expected.to eq([spec_path1]) }
+    it { is_expected.to eq(["./#{spec_path1}"]) }
 
     context 'when path does not match pattern' do
       let(:path1) { 'file1.rb' }

--- a/spec/predictor/helpers/path_formatter_spec.rb
+++ b/spec/predictor/helpers/path_formatter_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Crystalball::Predictor::Helpers::PathFormatter do
+  subject do
+    Object.new.tap { |obj| obj.extend(described_class) }
+  end
+
+  describe '#format_path' do
+    it 'adds ./ when missing' do
+      expect(subject.format_path('test.rb')).to eq './test.rb'
+    end
+
+    it 'does nothing when ./ is present' do
+      expect(subject.format_path('./test.rb')).to eq './test.rb'
+    end
+  end
+
+  describe '#format_paths' do
+    it 'returns an array of formatted paths' do
+      expect(subject.format_paths(['one.rb', './two.rb'])).to eq(['./one.rb', './two.rb'])
+    end
+  end
+end

--- a/spec/predictor/modified_execution_paths_spec.rb
+++ b/spec/predictor/modified_execution_paths_spec.rb
@@ -9,31 +9,31 @@ describe Crystalball::Predictor::ModifiedExecutionPaths do
   let(:file_diff1) { Crystalball::SourceDiff::FileDiff.new(Git::Diff::DiffFile.new(repository, path: path1)) }
   let(:diff) { [file_diff1] }
   let(:map) { instance_double('Crystalball::MapGenerator::ExecutionMap', cases: cases) }
-  let(:cases) { {spec_file: [path1]} }
+  let(:cases) { {'spec_file' => [path1]} }
   let(:path1) { 'file1.rb' }
 
   describe '#call' do
     subject { predictor.call(diff, map) }
 
-    it { is_expected.to eq([:spec_file]) }
+    it { is_expected.to eq(['./spec_file']) }
 
     context 'when no files match diff' do
-      let(:cases) { {spec_file: %w[file2.rb]} }
+      let(:cases) { {'spec_file' => %w[file2.rb]} }
 
       it { is_expected.to eq([]) }
     end
 
     context 'when some files match diff' do
-      let(:cases) { {spec_file: %w[file2.rb file1.rb]} }
+      let(:cases) { {'spec_file' => %w[file2.rb file1.rb]} }
 
-      it { is_expected.to eq([:spec_file]) }
+      it { is_expected.to eq(['./spec_file']) }
     end
 
     context 'when diff contains other unrelated files' do
       let(:file_diff2) { Crystalball::SourceDiff::FileDiff.new(Git::Diff::DiffFile.new(repository, path: 'file2.rb')) }
       let(:diff) { [file_diff1, file_diff2] }
 
-      it { is_expected.to eq([:spec_file]) }
+      it { is_expected.to eq(['./spec_file']) }
     end
   end
 end

--- a/spec/predictor/modified_specs_spec.rb
+++ b/spec/predictor/modified_specs_spec.rb
@@ -12,7 +12,7 @@ describe Crystalball::Predictor::ModifiedSpecs do
   describe '#call' do
     subject { predictor.call(diff, {}) }
 
-    it { is_expected.to eq([path1]) }
+    it { is_expected.to eq(["./#{path1}"]) }
 
     context 'when path does not match pattern' do
       let(:path1) { 'file1.rb' }

--- a/spec/predictor/modified_support_specs_spec.rb
+++ b/spec/predictor/modified_support_specs_spec.rb
@@ -14,7 +14,7 @@ describe Crystalball::Predictor::ModifiedSupportSpecs do
   describe '#call' do
     subject { predictor.call(diff, map) }
 
-    it { is_expected.to eq(['spec_file']) }
+    it { is_expected.to eq(['./spec_file']) }
 
     context 'when path does not match pattern' do
       let(:path1) { 'file1.rb' }

--- a/spec/predictor/strategy_spec.rb
+++ b/spec/predictor/strategy_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Crystalball::Predictor::Strategy do
+  subject do
+    Object.new.tap { |obj| obj.extend(described_class) }
+  end
+
+  describe '#call' do
+    it 'formats any output provided by implementation' do
+      expect(subject.call { ['one.rb', './two.rb'] }).to eq(['./one.rb', './two.rb'])
+    end
+  end
+end


### PR DESCRIPTION
Sometimes we return "spec/file1.rb" as a prediction, sometimes "./spec/file1.rb". 
This PR unifies the output to always be "./something".