### PR TITLE
Fix a :bug: in map expiration check

### DIFF
--- a/lib/crystalball/git_repo.rb
+++ b/lib/crystalball/git_repo.rb
@@ -31,6 +31,16 @@ module Crystalball
       diff.empty?
     end
 
+    # Fetches a commit from the repo without lazy evaluation.
+    # @return [Git::Object::Commit|nil]
+    def gcommit!(*args)
+      repo.gcommit(*args).tap do |c|
+        c.send :check_commit # Fetch commit data immediately
+      end
+    rescue Git::GitExecuteError
+      nil
+    end
+
     # Proxy all unknown calls to `Git` object
     def method_missing(method, *args, &block)
       repo.public_send(method, *args, &block) || super

--- a/lib/crystalball/rspec/prediction_builder.rb
+++ b/lib/crystalball/rspec/prediction_builder.rb
@@ -20,9 +20,9 @@ module Crystalball
       def expired_map?
         return false if config['map_expiration_period'] <= 0
 
-        map_commit = repo.gcommit(map.commit)
+        map_commit = repo.gcommit!(map.commit)
 
-        map_commit ||= repo.fetch && repo.gcommit(map.commit)
+        map_commit ||= repo.fetch && repo.gcommit!(map.commit)
 
         raise("Cant find map commit info #{map.commit}") unless map_commit
 

--- a/spec/git_repo_spec.rb
+++ b/spec/git_repo_spec.rb
@@ -73,6 +73,28 @@ describe Crystalball::GitRepo do
     end
   end
 
+  describe '#gcommit!' do
+    subject { git_repo.gcommit!(commit_sha) }
+    let(:commit_sha) { 'test' }
+    let(:commit) { instance_double('Git::Object::Commit').as_null_object }
+
+    context 'when commit can be fetched from tree' do
+      before do
+        allow_any_instance_of(Git::Base).to receive(:gcommit).with(commit_sha).and_return(commit)
+      end
+
+      it { is_expected.to eq commit }
+    end
+
+    context 'when commit fetching raises an error' do
+      before do
+        allow_any_instance_of(Git::Base).to receive(:gcommit).with(commit_sha).and_raise(Git::GitExecuteError)
+      end
+
+      it { is_expected.to eq nil }
+    end
+  end
+
   describe '#method_missing' do
     it 'delegates to #repo' do
       expect(subject.lib).to eq subject.instance_variable_get(:@repo).lib

--- a/spec/rspec/prediction_builder_spec.rb
+++ b/spec/rspec/prediction_builder_spec.rb
@@ -65,7 +65,7 @@ describe Crystalball::RSpec::PredictionBuilder do
 
       context 'when commit exists in the working tree' do
         before do
-          allow(repo).to receive(:gcommit).with(map_commit).and_return(commit_info)
+          allow(repo).to receive(:gcommit!).with(map_commit).and_return(commit_info)
         end
 
         context 'and map commit is too old' do
@@ -83,7 +83,7 @@ describe Crystalball::RSpec::PredictionBuilder do
 
       context 'when map commit doesnt exist in the working tree' do
         it 'tries to fetch repo remotes' do
-          allow(repo).to receive(:gcommit).with(map_commit).and_return(nil, commit_info)
+          allow(repo).to receive(:gcommit!).with(map_commit).and_return(nil, commit_info)
           expect(repo).to receive(:fetch).once.and_return(true)
           expect(subject).to eq false
         end


### PR DESCRIPTION
Fixes a bug with `expired_map?` check so it properly check for commit information in working tree