### PR TITLE
Disable compacting for RSpec runner

### DIFF
--- a/lib/crystalball/rspec/runner.rb
+++ b/lib/crystalball/rspec/runner.rb
@@ -76,7 +76,7 @@ module Crystalball
 
         def build_prediction(out)
           check_map(out) unless ENV['CRYSTALBALL_SKIP_MAP_CHECK']
-          prediction = prediction_builder.prediction.compact
+          prediction = prediction_builder.prediction.sort_by(&:length)
           out.puts "Prediction: #{prediction.first(5).join(' ')}#{'...' if prediction.size > 5}"
           out.puts "Starting RSpec."
           prediction

--- a/spec/rspec/runner_spec.rb
+++ b/spec/rspec/runner_spec.rb
@@ -83,7 +83,7 @@ describe Crystalball::RSpec::Runner do
 
   describe '.run' do
     let(:prediction_builder) do
-      instance_double('Crystalball::RSpec::PredictionBuilder', prediction: double(compact: compact_prediction), expired_map?: false)
+      instance_double('Crystalball::RSpec::PredictionBuilder', prediction: compact_prediction, expired_map?: false)
     end
     let(:compact_prediction) { ['test'] }
 


### PR DESCRIPTION
Compacting doesn't behave well with large prediction sets.
E.g. 50k examples prediction builds up around 5 seconds and compacts for 5 minutes.