### PR TITLE
Rework map expiration check

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,5 @@ Naming/UncommunicativeMethodParamName:
   Enabled: false
 Lint/SplatKeywordArguments:
   Enabled: false
+Style/MethodMissingSuper:
+  Enabled: false

--- a/lib/crystalball/execution_map.rb
+++ b/lib/crystalball/execution_map.rb
@@ -7,25 +7,26 @@ module Crystalball
 
     # Simple data object for map metadata information
     class Metadata
-      attr_reader :commit, :type, :version
+      attr_reader :commit, :type, :version, :timestamp
 
       # @param [String] commit - SHA of commit
       # @param [String] type - type of execution map
       # @param [Numeric] version - map generator version number
-      def initialize(commit: nil, type: nil, version: nil)
+      def initialize(commit: nil, type: nil, version: nil, timestamp: nil)
         @commit = commit
         @type = type
+        @timestamp = timestamp
         @version = version
       end
 
       def to_h
-        {type: type, commit: commit, version: version}
+        {type: type, commit: commit, timestamp: timestamp, version: version}
       end
     end
 
     attr_reader :cases, :metadata
 
-    delegate %i[commit version] => :metadata
+    delegate %i[commit version timestamp] => :metadata
     delegate %i[size] => :cases
 
     # @param [Hash] metadata - add or override metadata of execution map

--- a/lib/crystalball/git_repo.rb
+++ b/lib/crystalball/git_repo.rb
@@ -28,11 +28,11 @@ module Crystalball
 
     # Proxy all unknown calls to `Git` object
     def method_missing(method, *args, &block)
-      repo.public_send(method, *args, &block) || super
+      repo.public_send(method, *args, &block)
     end
 
     def respond_to_missing?(method, *)
-      repo.respond_to?(method, false) || super
+      repo.respond_to?(method, false)
     end
 
     # Creates diff

--- a/lib/crystalball/git_repo.rb
+++ b/lib/crystalball/git_repo.rb
@@ -26,21 +26,6 @@ module Crystalball
       @repo_path = repo_path
     end
 
-    # Check if repository has no uncommitted changes
-    def pristine?
-      diff.empty?
-    end
-
-    # Fetches a commit from the repo without lazy evaluation.
-    # @return [Git::Object::Commit|nil]
-    def gcommit!(*args)
-      repo.gcommit(*args).tap do |c|
-        c.send :check_commit # Fetch commit data immediately
-      end
-    rescue Git::GitExecuteError
-      nil
-    end
-
     # Proxy all unknown calls to `Git` object
     def method_missing(method, *args, &block)
       repo.public_send(method, *args, &block) || super

--- a/lib/crystalball/map_generator.rb
+++ b/lib/crystalball/map_generator.rb
@@ -27,7 +27,7 @@ module Crystalball
 
     def initialize
       @configuration = Configuration.new
-      @configuration.commit = repo.object('HEAD').sha if repo
+      @configuration.commit = repo.gcommit('HEAD') if repo
       yield @configuration if block_given?
     end
 
@@ -58,7 +58,7 @@ module Crystalball
     end
 
     def map
-      @map ||= map_class.new(metadata: {commit: configuration.commit, version: configuration.version})
+      @map ||= map_class.new(metadata: {commit: configuration.commit&.sha, timestamp: configuration.commit&.date&.to_i, version: configuration.version})
     end
 
     private

--- a/lib/crystalball/map_generator.rb
+++ b/lib/crystalball/map_generator.rb
@@ -33,8 +33,6 @@ module Crystalball
 
     # Registers strategies and prepares metadata for execution map
     def start!
-      raise 'Repository is not pristine! Please stash all your changes' if repo && !repo.pristine?
-
       self.map = nil
       map_storage.clear!
       map_storage.dump(map.metadata.to_h)

--- a/lib/crystalball/rails/helpers/base_schema_parser.rb
+++ b/lib/crystalball/rails/helpers/base_schema_parser.rb
@@ -19,7 +19,7 @@ module Crystalball
         private
 
         # Store info about call in hash. First argument of method call used as a key
-        def method_missing(method_name, *args, &block) # rubocop:disable Style/MethodMissingSuper
+        def method_missing(method_name, *args, &block)
           name = args.shift
           add_to_hash(name, options: [method_name] + args)
 

--- a/lib/crystalball/rspec/prediction_builder.rb
+++ b/lib/crystalball/rspec/prediction_builder.rb
@@ -21,13 +21,7 @@ module Crystalball
         expiration_period = config['map_expiration_period'].to_i
         return false unless expiration_period.positive?
 
-        map_commit = repo.gcommit!(execution_map.commit)
-
-        map_commit ||= repo.fetch && repo.gcommit!(execution_map.commit)
-
-        raise("Cant find map commit info #{execution_map.commit}") unless map_commit
-
-        map_commit.date < Time.now - expiration_period
+        execution_map.timestamp.to_i <= Time.now.to_i - config['map_expiration_period']
       end
 
       def execution_map

--- a/spec/git_repo_spec.rb
+++ b/spec/git_repo_spec.rb
@@ -57,44 +57,6 @@ describe Crystalball::GitRepo do
     end
   end
 
-  describe '#pristine?' do
-    context 'with untouched repo' do
-      before do
-        allow_any_instance_of(Crystalball::SourceDiff).to receive(:empty?).and_return(true)
-      end
-      it { is_expected.to be_pristine }
-    end
-
-    context 'with non-empty source diff' do
-      before do
-        allow_any_instance_of(Crystalball::SourceDiff).to receive(:empty?).and_return(false)
-      end
-      it { is_expected.not_to be_pristine }
-    end
-  end
-
-  describe '#gcommit!' do
-    subject { git_repo.gcommit!(commit_sha) }
-    let(:commit_sha) { 'test' }
-    let(:commit) { instance_double('Git::Object::Commit').as_null_object }
-
-    context 'when commit can be fetched from tree' do
-      before do
-        allow_any_instance_of(Git::Base).to receive(:gcommit).with(commit_sha).and_return(commit)
-      end
-
-      it { is_expected.to eq commit }
-    end
-
-    context 'when commit fetching raises an error' do
-      before do
-        allow_any_instance_of(Git::Base).to receive(:gcommit).with(commit_sha).and_raise(Git::GitExecuteError)
-      end
-
-      it { is_expected.to eq nil }
-    end
-  end
-
   describe '#method_missing' do
     it 'delegates to #repo' do
       expect(subject.lib).to eq subject.instance_variable_get(:@repo).lib

--- a/spec/map_generator_spec.rb
+++ b/spec/map_generator_spec.rb
@@ -43,9 +43,11 @@ describe Crystalball::MapGenerator do
   describe '#configuration' do
     describe '.commit' do
       subject { configuration.commit }
+      let(:commit) { double }
+
       it 'is git repo HEAD by default' do
-        allow_any_instance_of(Git::Base).to receive(:object).with('HEAD').and_return(double(sha: 'abc'))
-        expect(subject).to eq 'abc'
+        allow_any_instance_of(Git::Base).to receive(:gcommit).with('HEAD').and_return(commit)
+        expect(subject).to eq commit
       end
 
       context 'when repo does not exist' do
@@ -68,7 +70,7 @@ describe Crystalball::MapGenerator do
     end
 
     before do
-      configuration.commit = 'abc'
+      configuration.commit = double(sha: 'abc', date: 1234)
       configuration.dump_threshold = threshold
       configuration.map_storage = storage
       configuration.register dummy_strategy
@@ -88,7 +90,7 @@ describe Crystalball::MapGenerator do
       end
 
       it 'dump new map metadata to storage' do
-        expect(storage).to receive(:dump).with(type: map_class.to_s, commit: 'abc', version: 1.0)
+        expect(storage).to receive(:dump).with(type: map_class.to_s, commit: 'abc', timestamp: 1234, version: 1.0)
         subject.start!
       end
 

--- a/spec/map_generator_spec.rb
+++ b/spec/map_generator_spec.rb
@@ -78,10 +78,6 @@ describe Crystalball::MapGenerator do
     end
 
     describe '#start!' do
-      before do
-        allow_any_instance_of(Crystalball::GitRepo).to receive(:pristine?).and_return(true)
-      end
-
       it 'wipes the map and clears storage' do
         expect(storage).to receive :clear!
         expect do
@@ -92,12 +88,6 @@ describe Crystalball::MapGenerator do
       it 'dump new map metadata to storage' do
         expect(storage).to receive(:dump).with(type: map_class.to_s, commit: 'abc', timestamp: 1234, version: 1.0)
         subject.start!
-      end
-
-      it 'fails if repo is not pristine' do
-        allow_any_instance_of(Crystalball::GitRepo).to receive(:pristine?).and_return(false)
-
-        expect { subject.start! }.to raise_error(StandardError, 'Repository is not pristine! Please stash all your changes')
       end
 
       it 'calls after_start for each registered strategy' do

--- a/spec/rails/tables_map_generator_spec.rb
+++ b/spec/rails/tables_map_generator_spec.rb
@@ -66,10 +66,6 @@ describe Crystalball::Rails::TablesMapGenerator do
     end
 
     describe '#start!' do
-      before do
-        allow_any_instance_of(Crystalball::GitRepo).to receive(:pristine?).and_return(true)
-      end
-
       it 'wipes the map and clears storage' do
         expect(storage).to receive :clear!
         expect do

--- a/spec/rspec/prediction_builder_spec.rb
+++ b/spec/rspec/prediction_builder_spec.rb
@@ -22,14 +22,22 @@ describe Crystalball::RSpec::PredictionBuilder do
   end
 
   describe '#prediction' do
-    let(:configuration) do
-      super().merge(
-        'diff_from' => 'HEAD~3',
-        'diff_to' => 'HEAD'
-      )
-    end
     it 'raises NotImplementedError by default' do
       expect { builder.prediction }.to raise_error NotImplementedError
+    end
+
+    context 'with predictor configured' do
+      before do
+        builder.define_singleton_method(:predictor) do
+          super() {}
+        end
+      end
+
+      it 'delegates to predictor' do
+        expected_prediction = double
+        allow_any_instance_of(Crystalball::Predictor).to receive(:prediction).and_return expected_prediction
+        expect(builder.prediction).to eq expected_prediction
+      end
     end
   end
 

--- a/spec/rspec/prediction_builder_spec.rb
+++ b/spec/rspec/prediction_builder_spec.rb
@@ -47,35 +47,20 @@ describe Crystalball::RSpec::PredictionBuilder do
       let(:configuration) do
         super().merge('map_expiration_period' => 10)
       end
-      let(:commit_date) { Time.now - 5 }
-      let(:commit_info) { double(date: commit_date) }
-      let(:map_commit) { double }
 
-      before { allow(map).to receive(:commit).and_return(map_commit) }
+      before { allow(map).to receive(:timestamp).and_return(timestamp) }
 
       context 'when commit exists in the working tree' do
-        before do
-          allow(repo).to receive(:gcommit!).with(map_commit).and_return(commit_info)
-        end
-
         context 'and map commit is too old' do
-          let(:commit_date) { Time.now - 10 }
+          let(:timestamp) { Time.now.to_i - 10 }
 
           it { is_expected.to eq true }
         end
 
         context 'and map commit is fresh enough' do
-          let(:commit_date) { Time.now - 9 }
+          let(:timestamp) { Time.now.to_i - 9 }
 
           it { is_expected.to eq false }
-        end
-      end
-
-      context 'when map commit doesnt exist in the working tree' do
-        it 'tries to fetch repo remotes' do
-          allow(repo).to receive(:gcommit!).with(map_commit).and_return(nil, commit_info)
-          expect(repo).to receive(:fetch).once.and_return(true)
-          expect(subject).to eq false
         end
       end
     end


### PR DESCRIPTION
Previously we were fetching map date from working tree logs. We had to do `git fetch` because of edge case when the map was generated on a commit which is not in local working tree. However doing `git fetch` can be confusing and unexpected for some users. This PR reworks map expiration check in a way that does not require fetching