### PR TITLE
Allow config values overriding

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,15 +209,19 @@ There is a custom RSpec runner you can use in your development with `bundle exec
 
 #### Config file
 
-Create a YAML file for the runner. Default locations are `./crystalball.yml` and `./config/crystalball.yml`. You can override config path with `CRYSTALBALL_CONFIG` env variable.
+Create a YAML file for the runner. Default locations are `./crystalball.yml` and `./config/crystalball.yml`.
 Please check an [example of a config file](https://github.com/toptal/crystalball/blob/master/spec/fixtures/crystalball.yml) for available options
 
 #### Overriding config file
 
-If you want to override default path to config file please pass `CRYSTALBALL_CONFIG=path/to/crystalball.yml` env variable to Crystalball runner.
+If you want to override the path to config file please set `CRYSTALBALL_CONFIG=path/to/crystalball.yml` env variable.
 
 Any specific configuration option in `crystalball.yml` can be overridden by providing ENV variable with "CRYSTALBALL_" prefix. 
-E.g. "CRYSTALBALL_EXAMPLES_LIMIT=10" will set examples limit value to 10 regardless of what you have in config file.
+E.g. "CRYSTALBALL_EXAMPLES_LIMIT=10" will set `examples_limit` value to 10 regardless of what you have in config file.
+More examples:
+* `CRYSTALBALL_EXAMPLES_LIMIT=0` sets no limit on prediction size
+* `CRYSTALBALL_MAP_EXPIRATION_PERIOD=0` sets no expiration period for maps
+* `CRYSTALBALL_DIFF_FROM=origin/master` changes diff building to be `git diff origin/master`
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -212,11 +212,12 @@ There is a custom RSpec runner you can use in your development with `bundle exec
 Create a YAML file for the runner. Default locations are `./crystalball.yml` and `./config/crystalball.yml`. You can override config path with `CRYSTALBALL_CONFIG` env variable.
 Please check an [example of a config file](https://github.com/toptal/crystalball/blob/master/spec/fixtures/crystalball.yml) for available options
 
-#### Environment variables
+#### Overriding config file
 
-`CRYSTALBALL_CONFIG=path/to/crystalball.yml` if you want to override default path to config file.  
-`CRYSTALBALL_SKIP_MAP_CHECK=true` if you want to skip maps expiration period check.  
-`CRYSTALBALL_SKIP_EXAMPLES_LIMIT=true` if you want to skip examples limit check.
+If you want to override default path to config file please pass `CRYSTALBALL_CONFIG=path/to/crystalball.yml` env variable to Crystalball runner.
+
+Any specific configuration option in `crystalball.yml` can be overridden by providing ENV variable with "CRYSTALBALL_" prefix. 
+E.g. "CRYSTALBALL_EXAMPLES_LIMIT=10" will set examples limit value to 10 regardless of what you have in config file.
 
 ## Development
 

--- a/lib/crystalball/rspec/prediction_builder.rb
+++ b/lib/crystalball/rspec/prediction_builder.rb
@@ -18,7 +18,8 @@ module Crystalball
       end
 
       def expired_map?
-        return false if config['map_expiration_period'] <= 0
+        expiration_period = config['map_expiration_period'].to_i
+        return false unless expiration_period.positive?
 
         map_commit = repo.gcommit!(execution_map.commit)
 
@@ -26,7 +27,7 @@ module Crystalball
 
         raise("Cant find map commit info #{execution_map.commit}") unless map_commit
 
-        map_commit.date < Time.now - config['map_expiration_period']
+        map_commit.date < Time.now - expiration_period
       end
 
       def execution_map

--- a/lib/crystalball/rspec/runner.rb
+++ b/lib/crystalball/rspec/runner.rb
@@ -47,7 +47,7 @@ module Crystalball
 
         def check_limit(out)
           limit = config['examples_limit'].to_i
-          return if ENV['CRYSTALBALL_SKIP_EXAMPLES_LIMIT'] || !limit.positive?
+          return unless limit.positive?
 
           examples_count = yield
           return if examples_count <= limit
@@ -60,7 +60,7 @@ module Crystalball
         protected
 
         def load_execution_map
-          check_map($stdout) unless ENV['CRYSTALBALL_SKIP_MAP_CHECK']
+          check_map($stdout)
           prediction_builder.execution_map
         end
 
@@ -75,7 +75,7 @@ module Crystalball
         end
 
         def build_prediction(out)
-          check_map(out) unless ENV['CRYSTALBALL_SKIP_MAP_CHECK']
+          check_map(out)
           prediction = prediction_builder.prediction.sort_by(&:length)
           out.puts "Prediction: #{prediction.first(5).join(' ')}#{'...' if prediction.size > 5}"
           out.puts "Starting RSpec."

--- a/lib/crystalball/rspec/runner/configuration.rb
+++ b/lib/crystalball/rspec/runner/configuration.rb
@@ -22,7 +22,7 @@ module Crystalball
 
         def to_h
           dynamic_values = {}
-          (private_methods - Object.private_instance_methods - %i[run_requires values]).each do |method|
+          (private_methods - Object.private_instance_methods - %i[run_requires values raw_value]).each do |method|
             dynamic_values[method.to_s] = send(method)
           end
 
@@ -30,10 +30,14 @@ module Crystalball
         end
 
         def [](key)
-          respond_to?(key, true) ? send(key) : values[key]
+          respond_to?(key, true) ? send(key) : raw_value(key)
         end
 
         private
+
+        def raw_value(key)
+          ENV.fetch("CRYSTALBALL_#{key.to_s.upcase}", values[key])
+        end
 
         def prediction_builder_class
           @prediction_builder_class ||= begin
@@ -52,11 +56,11 @@ module Crystalball
         end
 
         def execution_map_path
-          @execution_map_path ||= Pathname.new(values['execution_map_path'])
+          @execution_map_path ||= Pathname.new(raw_value('execution_map_path'))
         end
 
         def repo_path
-          @repo_path ||= Pathname.new(values['repo_path'])
+          @repo_path ||= Pathname.new(raw_value('repo_path'))
         end
 
         attr_reader :values

--- a/spec/rspec/runner/configuration_spec.rb
+++ b/spec/rspec/runner/configuration_spec.rb
@@ -68,5 +68,21 @@ describe Crystalball::RSpec::Runner::Configuration do
     it 'returns other custom attributes as is' do
       expect(config['custom']).to eq 42
     end
+
+    context 'with ENV overrides' do
+      around do |example|
+        value = ENV['CRYSTALBALL_DIFF_FROM']
+        begin
+          ENV['CRYSTALBALL_DIFF_FROM'] = 'origin/master'
+          example.call
+        ensure
+          ENV['CRYSTALBALL_DIFF_FROM'] = value
+        end
+      end
+
+      it 'prioritizes ENV variable' do
+        expect(config['diff_from']).to eq 'origin/master'
+      end
+    end
   end
 end

--- a/spec/rspec/runner_spec.rb
+++ b/spec/rspec/runner_spec.rb
@@ -97,21 +97,8 @@ describe Crystalball::RSpec::Runner do
 
       after { ENV.delete('CRYSTALBALL_CONFIG') }
 
-      it 'exits RSpec ' do
+      it 'exits RSpec' do
         expect { described_class.run([]) }.to raise_error SystemExit
-      end
-
-      context 'and CRYSTALBALL_SKIP_EXAMPLES_LIMIT set' do
-        around do |example|
-          ENV['CRYSTALBALL_SKIP_EXAMPLES_LIMIT'] = '1'
-          example.call
-          ENV.delete('CRYSTALBALL_SKIP_EXAMPLES_LIMIT')
-        end
-
-        it 'runs examples' do
-          expect(RSpec::Core::ExampleGroup).to receive(:run)
-          expect { described_class.run([]) }.not_to raise_error
-        end
       end
     end
 


### PR DESCRIPTION
This feature will allow any config value overriding with ENV variable. Can be useful for overriding `diff_from` or `examples_limit` config values.