### PR TITLE
Flag the strategy used to predict files in case map

### DIFF
--- a/lib/crystalball/case_map.rb
+++ b/lib/crystalball/case_map.rb
@@ -4,16 +4,21 @@ module Crystalball
   # Data object to store execution map for specific example
   class CaseMap
     attr_reader :uid, :file_path, :affected_files
-    extend Forwardable
-
-    delegate %i[push each] => :affected_files
 
     # @param [String] example - id of example
     # @param [Array<String>] affected_files - list of files affected by example
-    def initialize(example, affected_files = [])
+    def initialize(example, affected_files = {})
       @uid = example.id
       @file_path = example.file_path
       @affected_files = affected_files
+    end
+
+    def push(*files, strategy:)
+      (affected_files[strategy] ||= []).push(*files)
+    end
+
+    def each(&block)
+      affected_files.values.flatten.uniq.each(&block)
     end
   end
 end

--- a/lib/crystalball/execution_map.rb
+++ b/lib/crystalball/execution_map.rb
@@ -41,7 +41,7 @@ module Crystalball
     #
     # @param [Crystalball::CaseMap] case_map
     def <<(case_map)
-      cases[case_map.uid] = case_map.affected_files.uniq
+      cases[case_map.uid] = case_map.affected_files.select { |_, v| v.any? }
     end
 
     # Remove all cases

--- a/lib/crystalball/map_generator/allocated_objects_strategy.rb
+++ b/lib/crystalball/map_generator/allocated_objects_strategy.rb
@@ -37,7 +37,7 @@ module Crystalball
         classes = object_tracker.used_classes_during do
           yield case_map, example
         end
-        case_map.push(*execution_detector.detect(classes))
+        case_map.push(*execution_detector.detect(classes), strategy: name)
       end
     end
   end

--- a/lib/crystalball/map_generator/base_strategy.rb
+++ b/lib/crystalball/map_generator/base_strategy.rb
@@ -10,6 +10,12 @@ module Crystalball
 
       def before_finalize; end
 
+      def name
+        self.class.name.split('::').last
+          .gsub(/(.)([A-Z])/,'\1_\2')
+          .downcase
+      end
+
       # Each strategy must implement #call augmenting the affected_files list and
       # yielding back the CaseMap.
       # @param [Crystalball::CaseMap] _case_map - object holding example metadata and affected files

--- a/lib/crystalball/map_generator/coverage_strategy.rb
+++ b/lib/crystalball/map_generator/coverage_strategy.rb
@@ -27,7 +27,7 @@ module Crystalball
         before = Coverage.peek_result
         yield case_map
         after = Coverage.peek_result
-        case_map.push(*execution_detector.detect(before, after))
+        case_map.push(*execution_detector.detect(before, after), strategy: name)
       end
     end
   end

--- a/lib/crystalball/map_generator/described_class_strategy.rb
+++ b/lib/crystalball/map_generator/described_class_strategy.rb
@@ -28,7 +28,7 @@ module Crystalball
 
         described_class = example.metadata[:described_class]
 
-        case_map.push(*execution_detector.detect([described_class])) if described_class
+        case_map.push(*execution_detector.detect([described_class]), strategy: name) if described_class
       end
     end
   end

--- a/lib/crystalball/map_generator/parser_strategy.rb
+++ b/lib/crystalball/map_generator/parser_strategy.rb
@@ -38,7 +38,7 @@ module Crystalball
           used = const_definition_paths.select { |k, _| consts.include?(k) }.values
           paths.push(*used.flatten)
         end
-        case_map.push(*filter(paths))
+        case_map.push(*filter(paths), strategy: name)
       end
 
       private

--- a/lib/crystalball/predictor/helpers/affected_examples_detector.rb
+++ b/lib/crystalball/predictor/helpers/affected_examples_detector.rb
@@ -11,7 +11,13 @@ module Crystalball
         # @return [Array<String>] list of affected examples
         def detect_examples(files, map)
           map.cases.map do |uid, case_map|
-            uid if files.any? { |file| case_map.include?(file) }
+            uid if files.any? do |file|
+              if case_map.is_a?(Array) # support old version of map. TODO: remove it.
+                case_map.include?(file)
+              else
+                case_map.values.flatten.include?(file)
+              end
+            end
           end.compact
         end
       end

--- a/lib/crystalball/rails/map_generator/action_view_strategy.rb
+++ b/lib/crystalball/rails/map_generator/action_view_strategy.rb
@@ -38,7 +38,7 @@ module Crystalball
         def call(case_map, _)
           self.class.reset_views
           yield case_map
-          case_map.push(*filter(self.class.views))
+          case_map.push(*filter(self.class.views), strategy: name)
         end
       end
     end

--- a/lib/crystalball/rails/map_generator/i18n_strategy.rb
+++ b/lib/crystalball/rails/map_generator/i18n_strategy.rb
@@ -39,7 +39,7 @@ module Crystalball
         def call(case_map, _)
           self.class.reset_locale_files
           yield case_map
-          case_map.push(*filter(self.class.locale_files.compact))
+          case_map.push(*filter(self.class.locale_files.compact), strategy: name)
         end
       end
     end

--- a/spec/execution_map_spec.rb
+++ b/spec/execution_map_spec.rb
@@ -4,10 +4,10 @@ require 'spec_helper'
 
 describe Crystalball::ExecutionMap do
   subject { described_class.new }
-  let(:affected_files) { instance_double(Array) }
+  let(:affected_files) { instance_double(Hash) }
   let(:case_map) { instance_double(Crystalball::CaseMap, uid: 'file_spec.rb:1', affected_files: affected_files) }
 
-  before { allow(affected_files).to receive(:uniq) { affected_files } }
+  before { allow(affected_files).to receive(:select) { affected_files } }
 
   describe '#<<' do
     it 'adds case to data' do

--- a/spec/map_generator/allocated_objects_strategy_spec.rb
+++ b/spec/map_generator/allocated_objects_strategy_spec.rb
@@ -30,7 +30,7 @@ describe Crystalball::MapGenerator::AllocatedObjectsStrategy do
   describe '#call' do
     subject { strategy.call(case_map, 'example') {} }
 
-    let(:case_map) { [] }
+    let(:case_map) { instance_double('Crystalball::CaseMap', push: nil) }
     let(:objects) { [] }
 
     before do
@@ -45,9 +45,8 @@ describe Crystalball::MapGenerator::AllocatedObjectsStrategy do
     end
 
     it 'pushes affected files detected by detector to case map' do
-      expect do
-        subject
-      end.to change { case_map }.to [1, 2, 3]
+      expect(case_map).to receive(:push).with(1, 2, 3, strategy: 'allocated_objects_strategy')
+      subject
     end
   end
 end

--- a/spec/map_generator/coverage_strategy_spec.rb
+++ b/spec/map_generator/coverage_strategy_spec.rb
@@ -16,7 +16,7 @@ describe Crystalball::MapGenerator::CoverageStrategy do
   end
 
   describe '#call' do
-    let(:case_map) { [] }
+    let(:case_map) { instance_double('Crystalball::CaseMap', push: nil) }
     before do
       before = double
       after = double
@@ -26,9 +26,8 @@ describe Crystalball::MapGenerator::CoverageStrategy do
     end
 
     it 'pushes affected files detected by detector to case map' do
-      expect do
-        subject.call(case_map, 'example') {}
-      end.to change { case_map }.to [1, 2, 3]
+      expect(case_map).to receive(:push).with(1, 2, 3, strategy: 'coverage_strategy')
+      subject.call(case_map, 'example') {}
     end
 
     it 'yields case_map to a block' do

--- a/spec/map_generator/described_class_strategy_spec.rb
+++ b/spec/map_generator/described_class_strategy_spec.rb
@@ -12,7 +12,7 @@ describe Crystalball::MapGenerator::DescribedClassStrategy do
   describe '#call' do
     subject { strategy.call(case_map, example) {} }
 
-    let(:case_map) { [] }
+    let(:case_map) { instance_double('Crystalball::CaseMap', push: nil) }
     let(:objects) { [Dummy] }
     let(:example) { double(metadata: {described_class: Dummy}) }
 
@@ -28,9 +28,8 @@ describe Crystalball::MapGenerator::DescribedClassStrategy do
     end
 
     it 'pushes affected files detected by detector to case map' do
-      expect do
-        subject
-      end.to change { case_map }.to [1, 2, 3]
+      expect(case_map).to receive(:push).with(1, 2, 3, strategy: 'described_class_strategy')
+      subject
     end
   end
 end

--- a/spec/predictor/modified_execution_paths_spec.rb
+++ b/spec/predictor/modified_execution_paths_spec.rb
@@ -9,7 +9,7 @@ describe Crystalball::Predictor::ModifiedExecutionPaths do
   let(:file_diff1) { Crystalball::SourceDiff::FileDiff.new(Git::Diff::DiffFile.new(repository, path: path1)) }
   let(:diff) { [file_diff1] }
   let(:map) { instance_double('Crystalball::MapGenerator::ExecutionMap', cases: cases) }
-  let(:cases) { {'spec_file' => [path1]} }
+  let(:cases) { {'spec_file' => {some_strategy: [path1]} } }
   let(:path1) { 'file1.rb' }
 
   describe '#call' do
@@ -18,13 +18,13 @@ describe Crystalball::Predictor::ModifiedExecutionPaths do
     it { is_expected.to eq(['./spec_file']) }
 
     context 'when no files match diff' do
-      let(:cases) { {'spec_file' => %w[file2.rb]} }
+      let(:cases) { {'spec_file' => {some_strategy: %w[file2.rb]} } }
 
       it { is_expected.to eq([]) }
     end
 
     context 'when some files match diff' do
-      let(:cases) { {'spec_file' => %w[file2.rb file1.rb]} }
+      let(:cases) { {'spec_file' => {some_strategy: %w[file2.rb file1.rb]} } }
 
       it { is_expected.to eq(['./spec_file']) }
     end

--- a/spec/predictor/modified_support_specs_spec.rb
+++ b/spec/predictor/modified_support_specs_spec.rb
@@ -9,7 +9,7 @@ describe Crystalball::Predictor::ModifiedSupportSpecs do
   let(:file_diff1) { Crystalball::SourceDiff::FileDiff.new(Git::Diff::DiffFile.new(repository, path: path1)) }
   let(:diff) { [file_diff1] }
   let(:map) { instance_double('Crystalball::MapGenerator::StandardMap', cases: cases) }
-  let(:cases) { {'spec_file[1:2]': [path1]} }
+  let(:cases) { {'spec_file[1:2]': {some_strategy: [path1]} } }
 
   describe '#call' do
     subject { predictor.call(diff, map) }

--- a/spec/predictor_spec.rb
+++ b/spec/predictor_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe Crystalball::Predictor do
-  subject(:predictor) { described_class.new(instance_double('Crystalball::ExecutionMap', cases: cases), repository) }
+  subject(:predictor) { described_class.new(map, repository) }
   let(:cases) { {spec_file: %w[file1.rb]} }
   let(:repository) { instance_double('Crystalball::GitRepo', repo_path: Pathname('.')) }
   let(:map) { instance_double('Crystalball::MapGenerator::ExecutionMap', cases: cases) }

--- a/spec/rails/map_generator/action_view_strategy_spec.rb
+++ b/spec/rails/map_generator/action_view_strategy_spec.rb
@@ -26,16 +26,15 @@ describe Crystalball::Rails::MapGenerator::ActionViewStrategy do
   end
 
   describe '#call' do
-    let(:case_map) { [] }
+    let(:case_map) { instance_double('Crystalball::CaseMap', push: nil) }
 
     it 'pushes affected files to case map' do
       allow(strategy).to receive(:filter).with(['view']).and_return([1, 2, 3])
+      expect(case_map).to receive(:push).with(1, 2, 3, strategy: 'action_view_strategy')
 
-      expect do
-        subject.call(case_map, 'example') do
-          Crystalball::Rails::MapGenerator::ActionViewStrategy.views.push 'view'
-        end
-      end.to change { case_map }.to [1, 2, 3]
+      subject.call(case_map, 'example') do
+        Crystalball::Rails::MapGenerator::ActionViewStrategy.views.push 'view'
+      end
     end
 
     it 'yields case_map to a block' do

--- a/spec/rails/map_generator/i18n_strategy_spec.rb
+++ b/spec/rails/map_generator/i18n_strategy_spec.rb
@@ -26,16 +26,15 @@ describe Crystalball::Rails::MapGenerator::I18nStrategy do
   end
 
   describe '#call' do
-    let(:case_map) { [] }
+    let(:case_map) { instance_double('Crystalball::CaseMap', push: nil) }
 
     it 'pushes affected files to case map' do
       allow(strategy).to receive(:filter).with(['view']).and_return([1, 2, 3])
+      expect(case_map).to receive(:push).with(1, 2, 3, strategy: 'i18n_strategy')
 
-      expect do
-        subject.call(case_map, nil) do
-          Crystalball::Rails::MapGenerator::I18nStrategy.locale_files.push 'view'
-        end
-      end.to change { case_map }.to [1, 2, 3]
+      subject.call(case_map, nil) do
+        Crystalball::Rails::MapGenerator::I18nStrategy.locale_files.push 'view'
+      end
     end
 
     it 'yields case_map to a block' do

--- a/spec/rails/predictor/modified_schema_spec.rb
+++ b/spec/rails/predictor/modified_schema_spec.rb
@@ -30,7 +30,7 @@ describe Crystalball::Rails::Predictor::ModifiedSchema do
       let(:repository_lib) { spy }
       let(:schema_path) { 'db/schema.rb' }
       let(:execution_map) { instance_double('Crystalball::MapGenerator::ExecutionMap', cases: cases) }
-      let(:cases) { {spec_file: [model_path]} }
+      let(:cases) { {spec_file: {some_strategy: model_path} }}
       let(:model_path) { 'dummy.rb' }
 
       before do


### PR DESCRIPTION
This will allow us to select only the specs that were inferred
by individual strategies at prediction time. That way we can choose
between faster predictions with lower precision or thorough ones.

### Example case map
```yaml
"./spec/class1_spec.rb[1:1:1]":
  coverage_strategy:
  - spec/support/shared_examples/module1.rb
  - lib/module1.rb
  - lib/class1.rb
  allocated_objects_strategy:
  - lib/class1.rb
  - lib/class1_reopen.rb
  - lib/module1.rb
  described_class_strategy:
  - lib/class1.rb
  - lib/class1_reopen.rb
  - lib/module1.rb
  parser_strategy:
  - lib/module1.rb
```