### PR TITLE
Change limit behavior

### DIFF
--- a/features/rspec_runner_spec.rb
+++ b/features/rspec_runner_spec.rb
@@ -17,6 +17,8 @@ describe 'RSpec runner' do
   it 'checks limit' do
     change class1_path
 
-    is_expected.to match(/Aborting spec run/)
+    is_expected.to match(/Prediction size \d+ is over the limit \(1\)/)
+      .and match(/Prediction is pruned to fit the limit!/)
+      .and match(/1 example, 0 failures/)
   end
 end

--- a/lib/crystalball/rspec/examples_pruner.rb
+++ b/lib/crystalball/rspec/examples_pruner.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Crystalball
+  module RSpec
+    # A class to prune prediction size to specified limit.
+    class ExamplesPruner
+      attr_reader :world, :to
+
+      # @param [RSpec::Core::World] rspec_world RSpec world instance
+      # @param [Integer] to upper bound limit for prediction.
+      def initialize(rspec_world, to:)
+        @world = rspec_world
+        @to = to
+      end
+
+      def world_groups
+        @world_groups ||= world.ordered_example_groups
+      end
+
+      def pruned_groups
+        self.resulting_groups = []
+        self.resulting_size = 0
+
+        world_groups.each { |g| prune_to_limit(g) }
+
+        resulting_groups
+      end
+
+      private
+
+      attr_accessor :resulting_groups, :resulting_size
+
+      def add_group(group, group_size)
+        resulting_groups << group
+        self.resulting_size = resulting_size + group_size
+      end
+
+      def prune_to_limit(group)
+        return if resulting_size >= to
+
+        group_size = world.example_count([group])
+
+        if resulting_size + group_size > to
+          (group.descendants - [group]).each do |g|
+            prune_to_limit(g)
+          end
+        else
+          add_group(group, group_size)
+        end
+      end
+    end
+  end
+end

--- a/lib/crystalball/rspec/runner.rb
+++ b/lib/crystalball/rspec/runner.rb
@@ -12,6 +12,10 @@ module Crystalball
         def run(args, err = $stderr, out = $stdout)
           return config['runner_class'].run(args, err, out) unless config['runner_class'] == self
 
+          ::RSpec.configure do |c|
+            c.silence_filter_announcements = true
+          end
+
           out.puts "Crystalball starts to glow..."
           prediction = build_prediction(out)
 

--- a/spec/fixtures/crystalball.yml
+++ b/spec/fixtures/crystalball.yml
@@ -1,6 +1,7 @@
 # Custom path to your execution map. Can be file or folder. Default: `tmp/execution_map.yml`
 execution_map_path: 'execution_map.yml'
 # Maximum amount of examples which will be run automatically. Default: no limit.
+# If prediction size is over the limit Crystalball will prune prediction to fit the limit.
 examples_limit: 1
 #
 # Custom prediction builder class to use. Default: 'Crystalball::RSpec::StandardPredictionBuilder'

--- a/spec/rspec/examples_pruner_spec.rb
+++ b/spec/rspec/examples_pruner_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Crystalball::RSpec::ExamplesPruner  do
+  subject(:pruner) { described_class.new(world, to: limit) }
+
+  let(:world) { instance_double('RSpec::Core::World') }
+  let(:limit) { 100 }
+
+  describe '#world_groups' do
+    it 'returns example groups from RSpec world' do
+      groups = double
+      allow(world).to receive(:ordered_example_groups).and_return(groups)
+      expect(subject.world_groups).to eq groups
+    end
+  end
+
+  describe '#pruned_groups' do
+    subject { pruner.pruned_groups }
+
+    def self.rspec_group(name, size: 0, descendants: [])
+      let(name) do
+        subgroups = descendants.map { |d| send(d) }
+        stub_const("RSpecTestGroup::#{name.to_s.upcase}", Class.new(RSpec::Core::ExampleGroup)).tap do |klass|
+          allow(klass).to receive(:descendants).and_return([klass] + subgroups)
+          allow(world).to receive(:example_count).with([klass]).and_return(size)
+        end
+      end
+    end
+    rspec_group(:subgroup1, size: 1)
+    rspec_group(:subgroup2, size: 2)
+    rspec_group(:subgroup3, size: 3)
+    rspec_group(:subgroup4, size: 4)
+    rspec_group(:subgroup5, size: 5)
+    rspec_group(:subgroup6, size: 6)
+
+    rspec_group(:group1, size: 6, descendants: %i[subgroup1 subgroup2 subgroup3])
+    rspec_group(:group2, size: 15, descendants: %i[subgroup4 subgroup5 subgroup6])
+
+    before do
+      allow(world).to receive(:ordered_example_groups).and_return [group1, group2]
+    end
+
+    context 'when limit is more than total suite size' do
+      let(:limit) { 6 + 15 + 1 }
+
+      it { is_expected.to eq [group1, group2] }
+    end
+
+    context 'when limit is less than first group size' do
+      let(:limit) { 3 }
+
+      it { is_expected.to eq [subgroup1, subgroup2] }
+    end
+
+    context 'when limit cant be matched exactly' do
+      let(:limit) { 14 }
+
+      it 'does not go over the limit' do
+        is_expected.to eq [group1, subgroup4]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Current behavior of `examples_limit`is not so useful for local development because if we abort the process that means we can't do anything useful in this case. It would be more useful to write a warning about prediction size being over the limit and try to shrink prediction to specified limit size so we can provide at least some feedback.