### PR TITLE
Fix logger flaky spec

### DIFF
--- a/spec/logging_spec.rb
+++ b/spec/logging_spec.rb
@@ -10,18 +10,23 @@ RSpec.describe 'Logger' do
   let!(:file_logger) { ::Logger.new(log_file_output_stream) }
   let(:configured_level) { 'warn' }
 
-  before do
+  around do |example|
+    Crystalball.reset_logger
+
+    old_log_file = ENV['CRYSTALBALL_LOG_FILE']
     ENV['CRYSTALBALL_LOG_LEVEL'] = configured_level
     ENV['CRYSTALBALL_LOG_FILE'] = log_file
 
-    allow(::Logger).to receive(:new).with(STDOUT).and_return(stdout_logger)
-    allow(::Logger).to receive(:new).with(log_file).and_return(file_logger)
+    example.run
+
+    ENV['CRYSTALBALL_LOG_FILE'] = old_log_file
+    ENV.delete('CRYSTALBALL_LOG_LEVEL')
+    Crystalball.reset_logger
   end
 
-  after do
-    ENV.delete('CRYSTALBALL_LOG_LEVEL')
-    ENV.delete('CRYSTALBALL_LOG_FILE')
-    Crystalball.reset_logger
+  before do
+    allow(::Logger).to receive(:new).with(STDOUT).and_return(stdout_logger)
+    allow(::Logger).to receive(:new).with(log_file).and_return(file_logger)
   end
 
   it 'logs everything to file' do

--- a/spec/rspec/runner_spec.rb
+++ b/spec/rspec/runner_spec.rb
@@ -11,10 +11,7 @@ describe Crystalball::RSpec::Runner do
     described_class.reset!
     allow(Crystalball::MapStorage::YAMLStorage).to receive(:load).and_return(map)
     allow(RSpec::Core::ExampleGroup).to receive(:run)
-    ENV['CRYSTALBALL_LOG_FILE'] = '/dev/null'
   end
-
-  after { ENV.delete('CRYSTALBALL_LOG_FILE') }
 
   describe '.prepare' do
     let(:expected_config) { {'execution_map_path' => 'map.yml', 'map_expiration_period' => 0, 'prediction_builder_class_name' => 'Crystalball::RSpec::PredictionBuilder'} }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,4 +21,8 @@ RSpec.configure do |config|
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
   end
+
+  config.before(:suite) do
+    ENV['CRYSTALBALL_LOG_FILE'] = '/dev/null'
+  end
 end


### PR DESCRIPTION
This flaky spec is related to dirty logger configuration. Since the output streams are class instance variables, they need to be reset or they'll carry on to the next examples. It can be reproduced with `rspec './spec/logging_spec.rb[1:1]' './spec/rspec/runner_spec.rb[1:2:2:1]' --seed 30990`