### PR TITLE
Use a different map generator configuration for each feature

### DIFF
--- a/features/evaluation_spec.rb
+++ b/features/evaluation_spec.rb
@@ -9,6 +9,14 @@ describe 'Prediction evaluation' do
   end
   include_context 'simple git repository'
 
+  map_generator_config do
+    <<~CONFIG
+      Crystalball::MapGenerator.start! do |c|
+        c.register Crystalball::MapGenerator::CoverageStrategy.new
+      end
+    CONFIG
+  end
+
   let(:predictor) do
     Crystalball::Predictor.new(map, Crystalball::GitRepo.open(git.dir.path)) do |predictor|
       predictor.use Crystalball::Predictor::AssociatedSpecs.new from: %r{models/(?<file>.*).rb},

--- a/features/fixtures/simple_app/spec/spec_helper.rb
+++ b/features/fixtures/simple_app/spec/spec_helper.rb
@@ -12,17 +12,7 @@ require_relative '../../../../lib/crystalball/rails'
 require_relative '../../../../lib/crystalball/factory_bot'
 require_relative '../../../../lib/crystalball/map_generator/parser_strategy'
 
-Crystalball::MapGenerator.start! do |c|
-  c.register Crystalball::MapGenerator::CoverageStrategy.new
-  c.register Crystalball::MapGenerator::AllocatedObjectsStrategy.build(only: ['Object'])
-  c.register Crystalball::MapGenerator::DescribedClassStrategy.new
-  c.register Crystalball::Rails::MapGenerator::ActionViewStrategy.new
-  c.register Crystalball::Rails::MapGenerator::I18nStrategy.new
-  c.register Crystalball::MapGenerator::FactoryBotStrategy.new
-  c.register Crystalball::MapGenerator::ParserStrategy.new(pattern: %r{(lib/)})
-end
-
-Crystalball::Rails::TablesMapGenerator.start!
+# MAP_GENERATOR_CONFIG
 
 require_relative 'support/shared_examples/module1.rb'
 require_relative 'support/shared_contexts/action_view.rb'

--- a/features/modified_execution_paths/action_view_strategy/change_spec.rb
+++ b/features/modified_execution_paths/action_view_strategy/change_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative '../../feature_helper'
+
+describe 'Changing source file' do
+  include_context 'simple git repository'
+  include_context 'base forecast'
+
+  let(:strategies) do
+    [Crystalball::Predictor::ModifiedExecutionPaths.new]
+  end
+
+  context 'when dealing with views' do
+    let(:item_view_path) { root.join('views', '_item.html.erb') }
+
+    map_generator_config do
+      <<~CONFIG
+        Crystalball::MapGenerator.start! do |c|
+          c.register Crystalball::Rails::MapGenerator::ActionViewStrategy.new
+        end
+      CONFIG
+    end
+
+    it 'adds mapped examples to a prediction list for _item view' do
+      change item_view_path
+
+      expect(forecast).to include(
+        './spec/views/index.html.erb_spec.rb[1:1]',
+        './spec/views/index.html.erb_spec.rb[1:2]',
+        './spec/views/index.html.erb_spec.rb[1:3]',
+        './spec/views/show.html.erb_spec.rb[1:1]'
+      )
+    end
+  end
+end

--- a/features/modified_execution_paths/allocated_objects_strategy/change_spec.rb
+++ b/features/modified_execution_paths/allocated_objects_strategy/change_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require_relative '../../feature_helper'
+
+describe 'Changing source file' do
+  include_context 'simple git repository'
+  include_context 'class1 examples'
+  include_context 'base forecast'
+
+  map_generator_config do
+    <<~CONFIG
+      Crystalball::MapGenerator.start! do |c|
+        c.register Crystalball::MapGenerator::AllocatedObjectsStrategy.build(only: ['Object'])
+      end
+    CONFIG
+  end
+
+  let(:strategies) do
+    [Crystalball::Predictor::ModifiedExecutionPaths.new]
+  end
+
+  it 'adds mapped examples to a prediction list for Class1 definition' do
+    change class1_path
+
+    expect(forecast).to include(*class1_examples)
+  end
+
+  it 'adds mapped examples to a prediction list for Class1 reopen' do
+    class1_reopen_path = lib_path.join('class1_reopen.rb')
+    change class1_reopen_path
+
+    expect(forecast).to include(*class1_examples)
+  end
+
+  it 'adds mapped examples to a prediction list for Class2 definition' do
+    change class2_path
+
+    expect(forecast).to include(
+      './spec/class2_spec.rb[1:1:1]',
+      './spec/class2_spec.rb[1:1:2:1]',
+      './spec/class2_spec.rb[1:1:3:1]',
+      './spec/class2_spec.rb[1:1:4:1]',
+      './spec/class2_spec.rb[1:2:1]',
+      './spec/class2_spec.rb[1:3:1]',
+      './spec/class2_spec.rb[1:4:1]',
+      './spec/class2_spec.rb[1:4:1]',
+      './spec/class2_spec.rb[1:6:1]',
+      './spec/file_spec.rb[1:2]'
+    )
+  end
+
+  it 'adds mapped examples to a prediction list for Module1 definition' do
+    module1_path = lib_path.join('module1.rb')
+    change module1_path
+
+    expect(forecast).to include(
+      './spec/class1_spec.rb[1:1:1]',
+      './spec/class1_spec.rb[1:1:2:1]',
+      './spec/class1_spec.rb[1:1:3:1]',
+      './spec/class1_spec.rb[1:1:4:1]',
+      './spec/class1_spec.rb[1:2:1]',
+      './spec/class2_spec.rb[1:1:1]',
+      './spec/class2_spec.rb[1:1:2:1]',
+      './spec/class2_spec.rb[1:1:3:1]',
+      './spec/class2_spec.rb[1:1:4:1]',
+      './spec/class2_spec.rb[1:2:1]',
+      './spec/class2_spec.rb[1:4:1]',
+      './spec/file_spec.rb[1:2]'
+    )
+  end
+
+  it 'adds mapped examples to a prediction list for Module2 definition' do
+    module2_path = lib_path.join('module2.rb')
+    change module2_path
+
+    expect(forecast).to include(
+      './spec/class2_spec.rb[1:1:1]',
+      './spec/class2_spec.rb[1:1:2:1]',
+      './spec/class2_spec.rb[1:1:3:1]',
+      './spec/class2_spec.rb[1:1:4:1]',
+      './spec/class2_spec.rb[1:2:1]',
+      './spec/class2_spec.rb[1:3:1]',
+      './spec/class2_spec.rb[1:4:1]',
+      './spec/file_spec.rb[1:2]'
+    )
+  end
+
+  it 'adds mapped examples to a prediction list for Model1 definition' do
+    change model1_path
+
+    expect(forecast).to include(
+      './spec/models/model1_spec.rb[1:2:1]',
+      './spec/models/model1_spec.rb[1:3:1]',
+      './spec/models/model1_spec.rb[1:4:1]',
+      './spec/views/index.html.erb_spec.rb[1:1]',
+      './spec/views/index.html.erb_spec.rb[1:2]',
+      './spec/views/index.html.erb_spec.rb[1:3]',
+      './spec/views/show.html.erb_spec.rb[1:1]'
+    )
+  end
+end

--- a/features/modified_execution_paths/change_and_commit_spec.rb
+++ b/features/modified_execution_paths/change_and_commit_spec.rb
@@ -7,6 +7,14 @@ describe 'Changing and commiting a source file' do
   include_context 'class1 examples'
   include_context 'base forecast'
 
+  map_generator_config do
+    <<~CONFIG
+      Crystalball::MapGenerator.start! do |c|
+        c.register Crystalball::MapGenerator::CoverageStrategy.new
+      end
+    CONFIG
+  end
+
   let(:strategies) do
     [Crystalball::Predictor::ModifiedExecutionPaths.new]
   end

--- a/features/modified_execution_paths/change_formatting_only_spec.rb
+++ b/features/modified_execution_paths/change_formatting_only_spec.rb
@@ -7,6 +7,14 @@ describe 'Changing formatting in a source file' do
   include_context 'class1 examples'
   include_context 'base forecast'
 
+  map_generator_config do
+    <<~CONFIG
+      Crystalball::MapGenerator.start! do |c|
+        c.register Crystalball::MapGenerator::CoverageStrategy.new
+      end
+    CONFIG
+  end
+
   let(:strategies) do
     [Crystalball::Predictor::ModifiedExecutionPaths.new]
   end

--- a/features/modified_execution_paths/change_in_branch_spec.rb
+++ b/features/modified_execution_paths/change_in_branch_spec.rb
@@ -5,11 +5,27 @@ require_relative '../feature_helper'
 describe 'Changing source file in a branch' do
   include_context 'simple git repository'
   include_context 'class1 examples'
-  include_context 'model1 examples'
   include_context 'base forecast'
+
+  map_generator_config do
+    <<~CONFIG
+      Crystalball::MapGenerator.start! do |c|
+        c.register Crystalball::MapGenerator::DescribedClassStrategy.new
+      end
+    CONFIG
+  end
 
   let(:strategies) do
     [Crystalball::Predictor::ModifiedExecutionPaths.new]
+  end
+
+  let(:model1_examples) do
+    [
+      './spec/models/model1_spec.rb[1:1:1]',
+      './spec/models/model1_spec.rb[1:2:1]',
+      './spec/models/model1_spec.rb[1:3:1]',
+      './spec/models/model1_spec.rb[1:4:1]'
+    ]
   end
 
   before do

--- a/features/modified_execution_paths/delete_spec.rb
+++ b/features/modified_execution_paths/delete_spec.rb
@@ -7,6 +7,14 @@ describe 'Deleting source file' do
   include_context 'class1 examples'
   include_context 'base forecast'
 
+  map_generator_config do
+    <<~CONFIG
+      Crystalball::MapGenerator.start! do |c|
+        c.register Crystalball::MapGenerator::CoverageStrategy.new
+      end
+    CONFIG
+  end
+
   let(:strategies) do
     [Crystalball::Predictor::ModifiedExecutionPaths.new]
   end

--- a/features/modified_execution_paths/described_class_strategy/change_spec.rb
+++ b/features/modified_execution_paths/described_class_strategy/change_spec.rb
@@ -1,15 +1,33 @@
 # frozen_string_literal: true
 
-require_relative '../feature_helper'
+require_relative '../../feature_helper'
 
 describe 'Changing source file' do
   include_context 'simple git repository'
-  include_context 'class1 examples'
-  include_context 'model1 examples'
   include_context 'base forecast'
+
+  map_generator_config do
+    <<~CONFIG
+      Crystalball::MapGenerator.start! do |c|
+        c.register Crystalball::MapGenerator::DescribedClassStrategy.new
+      end
+    CONFIG
+  end
 
   let(:strategies) do
     [Crystalball::Predictor::ModifiedExecutionPaths.new]
+  end
+
+  let(:class1_examples) do
+    [
+      './spec/class1_spec.rb[1:1:1]',
+      './spec/class1_spec.rb[1:1:2:1]',
+      './spec/class1_spec.rb[1:1:3:1]',
+      './spec/class1_spec.rb[1:1:4:1]',
+      './spec/class1_spec.rb[1:2:1]',
+      './spec/class1_spec.rb[1:3:1]',
+      './spec/class1_spec.rb[1:4:1]'
+    ]
   end
 
   it 'adds mapped examples to a prediction list for Class1 definition' do
@@ -19,6 +37,7 @@ describe 'Changing source file' do
   end
 
   it 'adds mapped examples to a prediction list for Class1 reopen' do
+    class1_reopen_path = lib_path.join('class1_reopen.rb')
     change class1_reopen_path
 
     expect(forecast).to include(*class1_examples)
@@ -35,14 +54,13 @@ describe 'Changing source file' do
       './spec/class2_spec.rb[1:2:1]',
       './spec/class2_spec.rb[1:3:1]',
       './spec/class2_spec.rb[1:4:1]',
-      './spec/class2_spec.rb[1:4:1]',
       './spec/class2_spec.rb[1:5:1]',
-      './spec/class2_spec.rb[1:6:1]',
-      './spec/file_spec.rb[1:2]'
+      './spec/class2_spec.rb[1:6:1]'
     )
   end
 
   it 'adds mapped examples to a prediction list for Module1 definition' do
+    module1_path = lib_path.join('module1.rb')
     change module1_path
 
     expect(forecast).to include(
@@ -57,12 +75,12 @@ describe 'Changing source file' do
       './spec/class2_spec.rb[1:1:4:1]',
       './spec/class2_spec.rb[1:2:1]',
       './spec/class2_spec.rb[1:4:1]',
-      './spec/class2_spec.rb[1:5:1]',
-      './spec/file_spec.rb[1:2]'
+      './spec/class2_spec.rb[1:5:1]'
     )
   end
 
   it 'adds mapped examples to a prediction list for Module2 definition' do
+    module2_path = lib_path.join('module2.rb')
     change module2_path
 
     expect(forecast).to include(
@@ -73,60 +91,17 @@ describe 'Changing source file' do
       './spec/class2_spec.rb[1:2:1]',
       './spec/class2_spec.rb[1:3:1]',
       './spec/class2_spec.rb[1:4:1]',
-      './spec/class2_spec.rb[1:5:1]',
-      './spec/file_spec.rb[1:2]'
+      './spec/class2_spec.rb[1:5:1]'
     )
   end
 
   it 'adds mapped examples to a prediction list for Model1 definition' do
     change model1_path
 
-    expect(forecast).to include(*model1_examples)
-  end
-
-  it 'adds mapped examples to a prediction list for Model1 factory' do
-    change model1_factory_path
-
-    expect(forecast).to match_array([
-                                      './spec/models/model1_spec.rb[1:3:1]',
-                                      './spec/models/model1_spec.rb[1:4:1]'
-                                    ])
-  end
-
-  it 'adds mapped examples to a prediction list for Model1 factory modification' do
-    change model1_factory_modification_path
-
-    expect(forecast).to match_array([
-                                      './spec/models/model1_spec.rb[1:3:1]',
-                                      './spec/models/model1_spec.rb[1:4:1]'
-                                    ])
-  end
-
-  it 'adds mapped examples to a prediction list for _item view' do
-    change item_view_path
-
     expect(forecast).to include(
-      './spec/views/index.html.erb_spec.rb[1:1]',
-      './spec/views/index.html.erb_spec.rb[1:2]',
-      './spec/views/index.html.erb_spec.rb[1:3]',
-      './spec/views/show.html.erb_spec.rb[1:1]'
-    )
-  end
-
-  it 'adds mapped examples to a prediction list for name locale' do
-    change name_locale_path
-
-    expect(forecast).to include(
-      './spec/class1_spec.rb[1:3:1]',
-      './spec/class2_spec.rb[1:3:1]'
-    )
-  end
-
-  it 'adds mapped examples to a prediction list for value locale' do
-    change value_locale_path
-
-    expect(forecast).to include(
-      './spec/class2_spec.rb[1:6:1]'
+      './spec/models/model1_spec.rb[1:2:1]',
+      './spec/models/model1_spec.rb[1:3:1]',
+      './spec/models/model1_spec.rb[1:4:1]'
     )
   end
 end

--- a/features/modified_execution_paths/factory_bot_strategy/change_spec.rb
+++ b/features/modified_execution_paths/factory_bot_strategy/change_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require_relative '../../feature_helper'
+
+describe 'Changing source file' do
+  include_context 'simple git repository'
+  include_context 'base forecast'
+
+  let(:strategies) do
+    [Crystalball::Predictor::ModifiedExecutionPaths.new]
+  end
+
+  context 'when dealing with factories' do
+    map_generator_config do
+      <<~CONFIG
+        Crystalball::MapGenerator.start! do |c|
+          c.register Crystalball::MapGenerator::FactoryBotStrategy.new
+        end
+      CONFIG
+    end
+
+    it 'adds mapped examples to a prediction list for Model1 factory' do
+      model1_factory_path = spec_path.join('factories/model1s.rb')
+      change model1_factory_path
+
+      expect(forecast).to match_array([
+                                        './spec/models/model1_spec.rb[1:3:1]',
+                                        './spec/models/model1_spec.rb[1:4:1]'
+                                      ])
+    end
+
+    it 'adds mapped examples to a prediction list for Model1 factory modification' do
+      model1_factory_modification_path = spec_path.join('factories/model1s_modification.rb')
+      change model1_factory_modification_path
+
+      expect(forecast).to match_array([
+                                        './spec/models/model1_spec.rb[1:3:1]',
+                                        './spec/models/model1_spec.rb[1:4:1]'
+                                      ])
+    end
+  end
+end

--- a/features/modified_execution_paths/i18n_strategy/change_spec.rb
+++ b/features/modified_execution_paths/i18n_strategy/change_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require_relative '../../feature_helper'
+
+describe 'Changing source file' do
+  include_context 'simple git repository'
+  include_context 'base forecast'
+
+  let(:strategies) do
+    [Crystalball::Predictor::ModifiedExecutionPaths.new]
+  end
+
+  context 'when dealing with locales' do
+    let(:locales_path) { root.join('locales') }
+    let(:name_locale_path) { locales_path.join('name.yml') }
+    let(:value_locale_path) { locales_path.join('value.yml') }
+
+    map_generator_config do
+      <<~CONFIG
+        Crystalball::MapGenerator.start! do |c|
+          c.register Crystalball::Rails::MapGenerator::I18nStrategy.new
+        end
+      CONFIG
+    end
+
+    it 'adds mapped examples to a prediction list for name locale' do
+      change name_locale_path
+
+      expect(forecast).to include(
+        './spec/class1_spec.rb[1:3:1]',
+        './spec/class2_spec.rb[1:3:1]'
+      )
+    end
+
+    it 'adds mapped examples to a prediction list for value locale' do
+      change value_locale_path
+
+      expect(forecast).to include(
+        './spec/class2_spec.rb[1:6:1]'
+      )
+    end
+  end
+end

--- a/features/modified_execution_paths/move_spec.rb
+++ b/features/modified_execution_paths/move_spec.rb
@@ -7,6 +7,14 @@ describe 'Moving source file' do
   include_context 'class1 examples'
   include_context 'base forecast'
 
+  map_generator_config do
+    <<~CONFIG
+      Crystalball::MapGenerator.start! do |c|
+        c.register Crystalball::MapGenerator::CoverageStrategy.new
+      end
+    CONFIG
+  end
+
   let(:strategies) do
     [Crystalball::Predictor::ModifiedExecutionPaths.new]
   end

--- a/features/modified_execution_paths/parser_strategy/change_spec.rb
+++ b/features/modified_execution_paths/parser_strategy/change_spec.rb
@@ -1,10 +1,19 @@
 # frozen_string_literal: true
 
-require_relative '../feature_helper'
+require_relative '../../feature_helper'
 
 describe 'Changing source file with a class method call' do
   include_context 'base forecast'
   include_context 'simple git repository'
+
+  map_generator_config do
+    <<~CONFIG
+      Crystalball::MapGenerator.start! do |c|
+        c.register Crystalball::MapGenerator::CoverageStrategy.new
+        c.register Crystalball::MapGenerator::ParserStrategy.new(pattern: %r{(lib/)})
+      end
+    CONFIG
+  end
 
   let(:strategies) { [Crystalball::Predictor::ModifiedExecutionPaths.new] }
 

--- a/features/modified_schema/change_spec.rb
+++ b/features/modified_schema/change_spec.rb
@@ -2,10 +2,29 @@
 
 require_relative '../feature_helper'
 
-describe 'Changing schema file' do
+RSpec.describe 'Changing schema file' do
   include_context 'simple git repository'
-  include_context 'model1 examples'
   include_context 'base forecast'
+  let(:schema_path) { root.join('db', 'schema.rb') }
+
+  map_generator_config do
+    <<~CONFIG
+      Crystalball::MapGenerator.start! do |c|
+        c.register Crystalball::MapGenerator::DescribedClassStrategy.new
+      end
+
+      Crystalball::Rails::TablesMapGenerator.start!
+    CONFIG
+  end
+
+  let(:model1_examples) do
+    [
+      './spec/models/model1_spec.rb[1:1:1]',
+      './spec/models/model1_spec.rb[1:2:1]',
+      './spec/models/model1_spec.rb[1:3:1]',
+      './spec/models/model1_spec.rb[1:4:1]'
+    ]
+  end
 
   let(:strategies) do
     [Crystalball::Rails::Predictor::ModifiedSchema.new(tables_map_path: root.join('tables_map.yml'))]

--- a/features/modified_support_specs/change_spec.rb
+++ b/features/modified_support_specs/change_spec.rb
@@ -8,6 +8,14 @@ describe 'Changing support spec file' do
 
   let(:strategies) { [Crystalball::Predictor::ModifiedSupportSpecs.new] }
 
+  map_generator_config do
+    <<~CONFIG
+      Crystalball::MapGenerator.start! do |c|
+        c.register Crystalball::MapGenerator::CoverageStrategy.new
+      end
+    CONFIG
+  end
+
   it 'adds full spec to a prediction list' do
     change action_view_shared_context
 

--- a/features/modified_support_specs/delete_spec.rb
+++ b/features/modified_support_specs/delete_spec.rb
@@ -6,6 +6,14 @@ describe 'Deleting support spec file' do
   include_context 'simple git repository'
   include_context 'base forecast'
 
+  map_generator_config do
+    <<~CONFIG
+      Crystalball::MapGenerator.start! do |c|
+        c.register Crystalball::MapGenerator::CoverageStrategy.new
+      end
+    CONFIG
+  end
+
   let(:strategies) { [Crystalball::Predictor::ModifiedSupportSpecs.new] }
 
   it 'adds full spec to a prediction list' do

--- a/features/modified_support_specs/move_spec.rb
+++ b/features/modified_support_specs/move_spec.rb
@@ -6,6 +6,14 @@ describe 'Moving support spec file' do
   include_context 'simple git repository'
   include_context 'base forecast'
 
+  map_generator_config do
+    <<~CONFIG
+      Crystalball::MapGenerator.start! do |c|
+        c.register Crystalball::MapGenerator::CoverageStrategy.new
+      end
+    CONFIG
+  end
+
   let(:strategies) { [Crystalball::Predictor::ModifiedSupportSpecs.new] }
 
   it 'adds full spec to a prediction list' do

--- a/features/rspec_runner_spec.rb
+++ b/features/rspec_runner_spec.rb
@@ -10,6 +10,14 @@ describe 'RSpec runner' do
   let(:important_class_path) { root.join('lib/important_class.rb') }
   let(:other_important_class_path) { root.join('lib/other_important_class.rb') }
 
+  map_generator_config do
+    <<~CONFIG
+      Crystalball::MapGenerator.start! do |c|
+        c.register Crystalball::MapGenerator::CoverageStrategy.new
+      end
+    CONFIG
+  end
+
   before do
     ENV['CRYSTALBALL_LOG_LEVEL'] = 'debug'
     ENV['CRYSTALBALL_LOG_FILE'] = '/dev/null'


### PR DESCRIPTION
### Usage
```ruby
# features/my_shiny_feature_spec.rb
require 'feature_helper'

RSpec.describe 'My feature with map generator' do
  include_context 'simple git repository'
  let(:map_generator_config) do
    # must return a string containing the code that will be written in spec_helper.rb
    <<~CONFIG
      Crystalball::MapGenerator.start! do |c|
        c.register Crystalball::MapGenerator::CoverageStrategy.new
      end
      Crystalball::Rails::TablesMapGenerator.start! # if it also needs a table map
    CONFIG
  end
  # ...
end
```