### PR TITLE
Adjusts default location for mapping file

### DIFF
--- a/lib/crystalball/rspec/runner/configuration.rb
+++ b/lib/crystalball/rspec/runner/configuration.rb
@@ -9,7 +9,7 @@ module Crystalball
       class Configuration
         def initialize(config = {}) # rubocop:disable Metrics/MethodLength
           @values = {
-            'execution_map_path' => 'crystalball.yml',
+            'execution_map_path' => 'execution_map.yml',
             'map_expiration_period' => 86_400,
             'repo_path' => Dir.pwd,
             'requires' => [],

--- a/lib/crystalball/rspec/runner/configuration.rb
+++ b/lib/crystalball/rspec/runner/configuration.rb
@@ -9,7 +9,7 @@ module Crystalball
       class Configuration
         def initialize(config = {}) # rubocop:disable Metrics/MethodLength
           @values = {
-            'execution_map_path' => 'tmp/execution_map.yml',
+            'execution_map_path' => 'crystalball.yml',
             'map_expiration_period' => 86_400,
             'repo_path' => Dir.pwd,
             'requires' => [],

--- a/spec/rspec/runner/configuration_spec.rb
+++ b/spec/rspec/runner/configuration_spec.rb
@@ -10,7 +10,7 @@ describe Crystalball::RSpec::Runner::Configuration do
     specify do
       expect(config.to_h)
         .to match(
-          'execution_map_path' => Pathname('crystalball.yml'),
+          'execution_map_path' => Pathname('execution_map.yml'),
           'map_expiration_period' => 86_400,
           'repo_path' => Pathname(Dir.pwd),
           'prediction_builder_class_name' => 'Crystalball::RSpec::StandardPredictionBuilder',

--- a/spec/rspec/runner/configuration_spec.rb
+++ b/spec/rspec/runner/configuration_spec.rb
@@ -10,7 +10,7 @@ describe Crystalball::RSpec::Runner::Configuration do
     specify do
       expect(config.to_h)
         .to match(
-          'execution_map_path' => Pathname('tmp/execution_map.yml'),
+          'execution_map_path' => Pathname('crystalball.yml'),
           'map_expiration_period' => 86_400,
           'repo_path' => Pathname(Dir.pwd),
           'prediction_builder_class_name' => 'Crystalball::RSpec::StandardPredictionBuilder',


### PR DESCRIPTION
The "out of the box" configuration wants to see the mapping file at the root of the project.  This seems like a more sensible default.