### PR TITLE
Handle execution maps without example groups

### DIFF
--- a/lib/crystalball/map_storage/yaml_storage.rb
+++ b/lib/crystalball/map_storage/yaml_storage.rb
@@ -21,7 +21,7 @@ module Crystalball
 
           guard_metadata_consistency(meta)
 
-          Object.const_get(meta.first[:type]).new(metadata: meta.first, example_groups: example_groups.inject(&:merge!))
+          Object.const_get(meta.first[:type]).new(metadata: meta.first, example_groups: example_groups.compact.inject(&:merge!))
         end
 
         private

--- a/spec/map_storage/yaml_storage_spec.rb
+++ b/spec/map_storage/yaml_storage_spec.rb
@@ -45,6 +45,14 @@ describe Crystalball::MapStorage::YAMLStorage do
         expect(map.commit).to eq '123'
       end
 
+      context 'when one file has no example groups' do
+        let(:file_content2) { {commit: '123', type: 'Crystalball::ExecutionMap'}.to_yaml }
+
+        it 'ignores that file' do
+          expect(map.example_groups).to eq('UID1' => %w[1 2 3])
+        end
+      end
+
       context 'when metadata info is inconsistent' do
         let(:file_content2) do
           {commit: '456', type: 'Crystalball::ExecutionMap'}.to_yaml + {'UID100' => %w[a b c]}.to_yaml


### PR DESCRIPTION
We're parallelizing our tests on CI and generating multiple execution maps. 

Sometimes we don't actually run any tests on a specific worker, but an execution map is still generated without any example groups.

We ran into `no implicit conversion of nil into Hash`, so this PR compacts the example groups before merging them.

cc @MarkyMarkMcDonald