### PR TITLE
Update the development bundler verson to be more flexible

### DIFF
--- a/crystalball.gemspec
+++ b/crystalball.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'actionview'
   spec.add_development_dependency 'activerecord'
-  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "bundler", ">= 1.14"
   spec.add_development_dependency 'factory_bot'
   spec.add_development_dependency 'i18n'
   spec.add_development_dependency 'parser'


### PR DESCRIPTION
The bundler version for development conflicts with my bundler version (2.0.1).