### PR TITLE
Explicitly require forwardable in SourceDiff

### DIFF
--- a/lib/crystalball/source_diff.rb
+++ b/lib/crystalball/source_diff.rb
@@ -2,6 +2,7 @@
 
 require 'crystalball/source_diff/file_diff'
 require 'crystalball/source_diff/formatting_checker'
+require 'forwardable'
 
 module Crystalball
   # Wrapper class representing Git source diff for given repo


### PR DESCRIPTION
Resolves the following issue when running `bundle exec crystalball` (with bunder 2.0.1, ruby 2.4.5)

bundler: failed to load command: crystalball (/Users/kevin.bruccoleri/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/bin/crystalball)
NameError: uninitialized constant Crystalball::SourceDiff::Forwardable
  /Users/kevin.bruccoleri/code/crystalball/lib/crystalball/source_diff.rb:10:in `<class:SourceDiff>'
  /Users/kevin.bruccoleri/code/crystalball/lib/crystalball/source_diff.rb:8:in `<module:Crystalball>'
  /Users/kevin.bruccoleri/code/crystalball/lib/crystalball/source_diff.rb:6:in `<top (required)>'
  /Users/kevin.bruccoleri/code/crystalball/lib/crystalball/git_repo.rb:4:in `require'
  /Users/kevin.bruccoleri/code/crystalball/lib/crystalball/git_repo.rb:4:in `<top (required)>'
  /Users/kevin.bruccoleri/code/crystalball/lib/crystalball.rb:4:in `require'
  /Users/kevin.bruccoleri/code/crystalball/lib/crystalball.rb:4:in `<top (required)>'
  /Users/kevin.bruccoleri/code/crystalball/bin/crystalball:4:in `require'
  /Users/kevin.bruccoleri/code/crystalball/bin/crystalball:4:in `<top (required)>'
  /Users/kevin.bruccoleri/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/bin/crystalball:23:in `load'
  /Users/kevin.bruccoleri/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/bin/crystalball:23:in `<top (required)>'
