### PR TITLE
Fix SQLite Gem to 1.3.13

### DIFF
--- a/crystalball.gemspec
+++ b/crystalball.gemspec
@@ -47,6 +47,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', ">= 0.56"
   spec.add_development_dependency 'rubocop-rspec'
   spec.add_development_dependency 'simplecov'
-  spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'sqlite3', "~> 1.3.13"
   spec.add_development_dependency 'yard'
 end


### PR DESCRIPTION
The feature specs run rspec using a system call to determine whether or not they execution maps were being generated properly. By running the call and not piping it to dev/null, it seems that rspec was failing to run on the sample app due to a gem version misalignment between ActiveRecord and sqlite due to the recent release of sqlite 1.4.0. To solve the problem, I fixed the version to the most recent of sqlite that allowed the feature tests to pass.