### PR TITLE
Use factories.find instead of factory_by_name

### DIFF
--- a/lib/crystalball/map_generator/factory_bot_strategy/factory_runner_patch.rb
+++ b/lib/crystalball/map_generator/factory_bot_strategy/factory_runner_patch.rb
@@ -15,7 +15,7 @@ module Crystalball
         # Overrides `FactoryBot::FactoryRunner#run`. Pushes factory name to
         # `FactoryBotStrategy.used_factories` and calls original `run`
         def run(*)
-          factory = FactoryBotStrategy.factory_bot_constant.factory_by_name(@name)
+          factory = FactoryBotStrategy.factory_bot_constant.factories.find(@name)
           FactoryBotStrategy.used_factories << factory.name.to_s
           super
         end

--- a/spec/map_generator/factory_bot_strategy/factory_runner_patch_spec.rb
+++ b/spec/map_generator/factory_bot_strategy/factory_runner_patch_spec.rb
@@ -43,7 +43,7 @@ describe Crystalball::MapGenerator::FactoryBotStrategy::FactoryRunnerPatch do
 
     before do
       allow(Crystalball::MapGenerator::FactoryBotStrategy).to receive(:used_factories).and_return(used_factories)
-      allow(FactoryBotConstant).to receive(:factory_by_name).with(:bad_dummy) { double(name: :dummy) }
+      allow(FactoryBotConstant).to receive_message_chain(:factories, :find).with(:bad_dummy) { double(name: :dummy) }
       instance.instance_variable_set(:@name, :bad_dummy)
     end
 


### PR DESCRIPTION
Why? `factory_by_name` is deprecated since version 5.1 and will be removed in version 6.0;
More info at: https://github.com/thoughtbot/factory_bot/blob/master/NEWS.md#510-september-21-2019