### PR TITLE
Fix Simplecov integration

### DIFF
--- a/lib/crystalball/map_generator/coverage_strategy.rb
+++ b/lib/crystalball/map_generator/coverage_strategy.rb
@@ -17,7 +17,7 @@ module Crystalball
       end
 
       def after_register
-        Coverage.start
+        Coverage.start unless Coverage.running?
       end
 
       # Adds to the example_map's used files the ones the ones in which

--- a/spec/map_generator/coverage_strategy_spec.rb
+++ b/spec/map_generator/coverage_strategy_spec.rb
@@ -9,9 +9,20 @@ describe Crystalball::MapGenerator::CoverageStrategy do
   include_examples 'base strategy'
 
   describe '#after_register' do
-    it 'starts coverage' do
-      expect(Coverage).to receive(:start)
-      subject.after_register
+    context 'when Coverage is already running' do
+      it 'does nothing' do
+        allow(Coverage).to receive(:running?).and_return(true)
+        expect(Coverage).not_to receive(:start)
+        subject.after_register
+      end
+    end
+
+    context 'when Coverage is not running' do
+      it 'starts coverage' do
+        allow(Coverage).to receive(:running?).and_return(false)
+        expect(Coverage).to receive(:start)
+        subject.after_register
+      end
     end
   end
 


### PR DESCRIPTION
Why? Since the 0.18 version, `Simplecov.start` cannot be called twice.
So we only need to start Simplecov when it isn't running.